### PR TITLE
Use apps/v1 for Deployment object

### DIFF
--- a/artifacts/deploy/300_deployment.yaml
+++ b/artifacts/deploy/300_deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: clusterresourceoverride-operator


### PR DESCRIPTION
Potential fix for the following error 
```
error: unable to recognize "_output/deploy/300_deployment.yaml": no matches for kind "Deployment" in version "extensions/v1beta1"
make: *** [deploy] Error 1
```
 