### PR TITLE
Fix e2e-ci goal in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,9 @@ deploy:
 	$(KUBECTL) apply -f $(DEPLOY_DIR)
 
 
+e2e-ci: KUBECTL=/tmp/shared/oc
 e2e-ci: deploy-ci e2e
+
 e2e-local: deploy-local e2e
 
 e2e: OPERATOR_NAMESPACE := clusterresourceoverride-operator


### PR DESCRIPTION
Potential fix for the following error
```
kubectl -n clusterresourceoverride-operator rollout status -w deployment/clusterresourceoverride-operator
make: kubectl: Command not found
make: *** [e2e] Error 127
```