### PR TITLE
Bug 1801850: Overridden quantity must be below namespace Maximum

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,3 @@
-./bin/*
-
 manifests/art.yaml
 manifests/*/image-references
 

--- a/artifacts/deploy/200_rbac.yaml
+++ b/artifacts/deploy/200_rbac.yaml
@@ -96,11 +96,12 @@ rules:
     - list
     - watch
 
-  # to grant power to the operand to watch namespace(s)
+  # to grant power to the operand to watch Namespace(s) and LimitRange(s)
   - apiGroups:
     - ""
     resources:
     - namespaces
+    - limitranges
     verbs:
     - get
     - list

--- a/artifacts/example/test-pod-with-limitranges.yaml
+++ b/artifacts/example/test-pod-with-limitranges.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: example
+  namespace: test
+spec:
+  limits:
+  - type: Container
+    default:
+      cpu: "2000m"
+      memory: "512Mi"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example
+  labels:
+    app: hello-openshift
+  namespace: test
+spec:
+  containers:
+    - name: hello-openshift
+      image: openshift/hello-openshift
+      ports:
+        - containerPort: 8080
+

--- a/manifests/4.4/clusterresourceoverride-operator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/4.4/clusterresourceoverride-operator.v4.4.0.clusterserviceversion.yaml
@@ -223,11 +223,12 @@ spec:
             - list
             - watch
 
-        # to grant power to the operand to watch namespace(s)
+        # to grant power to the operand to watch Namespace(s) and LimitRange(s)
         - apiGroups:
             - ""
           resources:
             - namespaces
+            - limitranges
           verbs:
             - get
             - list

--- a/pkg/asset/rbac.go
+++ b/pkg/asset/rbac.go
@@ -135,12 +135,14 @@ func (s *rbac) New() []*RBACItem {
 							"watch",
 						},
 					},
+					// to give power to the operand to watch Namespace and LimitRange
 					{
 						APIGroups: []string{
 							"",
 						},
 						Resources: []string{
 							"namespaces",
+							"limitranges",
 						},
 						Verbs: []string{
 							"get",

--- a/pkg/asset/webhookconfiguration.go
+++ b/pkg/asset/webhookconfiguration.go
@@ -32,7 +32,7 @@ func (m *mutatingWebhookConfiguration) New() *admissionregistrationv1beta1.Mutat
 	namespaceMatchLabelKey := fmt.Sprintf("%s.%s/enabled", m.values.AdmissionAPIResource, m.values.AdmissionAPIGroup)
 	timeoutSeconds := int32(5)
 	sideEffects := admissionregistrationv1beta1.SideEffectClassNone
-
+	reinvoke := admissionregistrationv1beta1.IfNeededReinvocationPolicy
 	return &admissionregistrationv1beta1.MutatingWebhookConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "MutatingWebhookConfiguration",
@@ -88,9 +88,10 @@ func (m *mutatingWebhookConfiguration) New() *admissionregistrationv1beta1.Mutat
 						},
 					},
 				},
-				FailurePolicy:  &policy,
-				TimeoutSeconds: &timeoutSeconds,
-				SideEffects:    &sideEffects,
+				FailurePolicy:      &policy,
+				TimeoutSeconds:     &timeoutSeconds,
+				SideEffects:        &sideEffects,
+				ReinvocationPolicy: &reinvoke,
 			},
 		},
 	}

--- a/test/e2e/dynamic_test.go
+++ b/test/e2e/dynamic_test.go
@@ -1,0 +1,112 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/dynamic"
+	"github.com/openshift/cluster-resource-override-admission-operator/test/helper"
+)
+
+func TestDynamicClient(t *testing.T) {
+	client := helper.NewClient(t, options.config)
+
+	namespace := options.namespace
+	name := "test-dynamic-client"
+	var replicas int32 = 1
+	deployment := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Annotations: map[string]string{
+				"annotation1": "value1",
+			},
+			Labels: map[string]string{
+				"label1": "value1",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"selector1": "true",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+					Annotations: map[string]string{
+						"annotation1": "value1",
+					},
+					Labels: map[string]string{
+						"selector1": "true",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            name,
+							Image:           "openshift/hello-openshift",
+							ImagePullPolicy: corev1.PullAlways,
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: 8080,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	dynamic, err := dynamic.NewForConfig(options.config)
+	require.NoError(t, err)
+	require.NotNil(t, dynamic)
+
+	// ensure that this deployment does not exist.
+	_, err = client.Kubernetes.AppsV1().Deployments(namespace).Get(name, metav1.GetOptions{})
+	require.Truef(t, k8serrors.IsNotFound(err), "precondition failed - Deployment=%s/%s already exists", namespace, name)
+
+	// scenario 1: does not exist, create only.
+	objectGot, errGot := dynamic.Ensure("deployments", deployment)
+	require.NoError(t, errGot)
+	require.NotNil(t, objectGot)
+
+	defer func() {
+		err := client.Kubernetes.AppsV1().Deployments(namespace).Delete(name, &metav1.DeleteOptions{})
+		require.NoError(t, err)
+	}()
+
+	// update/patch
+	deployment.Annotations["annotation2"] = "value2"
+	deployment.Labels["label2"] = "value2"
+	deployment.Spec.Template.Labels["label2"] = "value2"
+	deployment.Spec.Template.Annotations["annotation2"] = "value2"
+
+	objectGot, errGot = dynamic.Ensure("deployments", deployment)
+	require.NoError(t, errGot)
+	require.NotNil(t, objectGot)
+
+	current, err := client.Kubernetes.AppsV1().Deployments(namespace).Get(name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.True(t, current.Annotations["annotation1"] == "value1", "original annotation not preserved")
+	require.True(t, current.Annotations["annotation2"] == "value2", "new annotation not applied")
+	require.True(t, current.Spec.Template.Annotations["annotation1"] == "value1", "original annotation in Spec.Template not preserved")
+	require.True(t, current.Spec.Template.Annotations["annotation2"] == "value2", "new annotation in Spec.Template not preserved")
+
+	require.True(t, current.Labels["label1"] == "value1", "original label not preserved")
+	require.True(t, current.Labels["label2"] == "value2", "new label not applied")
+	require.True(t, current.Spec.Template.Labels["selector1"] == "true", "original label in Spec.Template not preserved")
+	require.True(t, current.Spec.Template.Labels["label2"] == "value2", "new label in Spec.Template not applied")
+}

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -250,7 +250,7 @@ func IsMatch(t *testing.T, requirementsWant, requirementsGot corev1.ResourceRequ
 	quantityWant, ok := requirementsWant.Requests[corev1.ResourceMemory]
 	if ok {
 		quantityGot, ok := requirementsGot.Requests[corev1.ResourceMemory]
-		require.True(t, ok)
+		require.Truef(t, ok, "key=%s not found in %v", corev1.ResourceMemory, requirementsGot)
 		require.Truef(t, quantityWant.Equal(quantityGot), "type=request resource=%s expected=%v actual=%v",
 			corev1.ResourceMemory, quantityWant, quantityGot)
 	}
@@ -303,9 +303,11 @@ func MustMatchMemoryAndCPU(t *testing.T, resourceWant map[string]corev1.Resource
 
 func NewLimitRanges(t *testing.T, client kubernetes.Interface, namespace string, spec corev1.LimitRangeSpec) (object *corev1.LimitRange, disposer Disposer) {
 	request := corev1.LimitRange{
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{},
-		Spec:       corev1.LimitRangeSpec{},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "cro-limits-",
+			Namespace:    namespace,
+		},
+		Spec: spec,
 	}
 
 	object, err := client.CoreV1().LimitRanges(namespace).Create(&request)


### PR DESCRIPTION
The overridden quantity must be below the namespace Maximum specified via LimitRange object.

Currently the mutating admission webhook overrides a resource above
the namespace maximum and thus fails Pod creation, we see the
following error:
"pods "croe2e-f7c9h" is forbidden: maximum cpu usage per Container is 1, but limit is 2"

Query the Maximum limit for CPU and Memory resource specified in LimitRange and ensure that the overridden resource quantity never exceeds the namespace Maximum.

Add e2e tests:
- Ensure that dynamic client can create if specified object does not exist.
- Ensure that dynamic client can patch an existing object. It should preserve annotations/labels added to the object by cluster admins. It should add new labels/annotations specified.