### PR TITLE
Bug 1796987: Fix e2e with olm

### DIFF
--- a/hack/enable-art-dev-env.sh
+++ b/hack/enable-art-dev-env.sh
@@ -14,8 +14,13 @@ if [ "${QUAY_ROBOT_NAME}" == "" ]; then
   exit 1
 fi
 
+if [ "${QUAY_ROBOT_TOKEN}" == "" ]; then
+  echo "QUAY_ROBOT_TOKEN env must be set"
+  exit 1
+fi
+
 RESPONSE=$(curl -sH "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d '{ "user": { "username": "'"${QUAY_ROBOT_NAME}"'","password": "'"${QUAY_ROBOT_TOKEN}"'"}}')
-QUAY_TOKEN=$(jq -e -r '.token' <<< "${QUAY_TOKEN}" || echo "")
+QUAY_TOKEN=$(jq -e -r '.token' <<< "${RESPONSE}" || echo "")
 
 if [ "${QUAY_TOKEN}" == "" ]; then
   echo "failed to retrieve token response=${RESPONSE}"

--- a/images/operator-registry/Dockerfile.registry.ci
+++ b/images/operator-registry/Dockerfile.registry.ci
@@ -18,8 +18,8 @@ FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12
 ARG VERSION
 
 # copy required binaries and scripts
-COPY --from=registry-builder /build/bin/initializer /usr/bin/initializer
-COPY --from=registry-builder /build/bin/registry-server /usr/bin/registry-server
+COPY --from=registry-builder /bin/initializer /usr/bin/initializer
+COPY --from=registry-builder /bin/registry-server /usr/bin/registry-server
 COPY --from=registry-builder /bin/grpc_health_probe /usr/bin/grpc_health_probe
 COPY --from=operator-builder /scripts/registry-init.sh /scripts/registry-init.sh
 


### PR DESCRIPTION
 - Fix operator registry Dockerfile. The location of the operator registry binaries in 'upstream-registry-builder' have moved, fix the Dockerfile to account for the breaking change.

- Fix hack/enable-art-dev-env script
