### PR TITLE
Bug 1796987: e2e with olm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ e2e:
 # apply OLM resources to deploy the operator.
 olm-apply:
 	$(KUBECTL) apply -n $(OPERATOR_NAMESPACE) -f $(OLM_MANIFESTS_DIR)
-	./hack/wait-for-deployment.sh $(OPERATOR_NAMESPACE) $(OPERATOR_DEPLOYMENT_NAME) 500
+	./hack/wait-for-deployment.sh $(KUBECTL) $(OPERATOR_NAMESPACE) $(OPERATOR_DEPLOYMENT_NAME) 500
 
 # generate OLM resources (Subscription and OperatorGroup etc.) to install the operator via olm.
 olm-generate: OPERATOR_GROUP_FILE := "$(OLM_MANIFESTS_DIR)/operator-group.yaml"

--- a/hack/wait-for-deployment.sh
+++ b/hack/wait-for-deployment.sh
@@ -5,13 +5,16 @@ set -o nounset
 set -o pipefail
 
 util::await_operator_deployment_create() {
-    local namespace="$1"
-    local name="$2"
-    local retries="${3:-50}"
+    local kubectl="$1"
+    local namespace="$2"
+    local name="$3"
+    local retries="${4:-50}"
     local output
 
+    command -v ${kubectl} >/dev/null 2>&1 || { echo >&2 "${kubectl} not found, aborting."; exit 1; }
+
     until [[ "${retries}" -le "0" ]]; do
-        output=$(kubectl get deployment -n "${namespace}" "${name}" -o jsonpath='{.metadata.name}' 2>/dev/null || echo "waiting for olm to deploy the operator")
+        output=$(${kubectl} get deployment -n "${namespace}" "${name}" -o jsonpath='{.metadata.name}' 2>/dev/null || echo "waiting for olm to deploy the operator")
 
         if [ "${output}" = "${name}" ] ; then
             echo "${namespace}/${name} has been created" >&2
@@ -28,9 +31,10 @@ util::await_operator_deployment_create() {
     return 1
 }
 
-NAMESPACE=$1
-DEPLOYMENT_NAME=$2
-WAIT_TIME=$3
+KUBECTL=$1
+NAMESPACE=$2
+DEPLOYMENT_NAME=$3
+WAIT_TIME=$4
 
-exitcode=$(util::await_operator_deployment_create "${NAMESPACE}" "${DEPLOYMENT_NAME}" "${WAIT_TIME}")
+exitcode=$(util::await_operator_deployment_create "${KUBECTL}" "${NAMESPACE}" "${DEPLOYMENT_NAME}" "${WAIT_TIME}")
 exit $exitcode

--- a/manifests/4.4/clusterresourceoverride-operator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/4.4/clusterresourceoverride-operator.v4.4.0.clusterserviceversion.yaml
@@ -16,6 +16,11 @@ metadata:
   name: clusterresourceoverride-operator.v4.4.0
   namespace: clusterresourceoverride-operator
 spec:
+  relatedImages:
+  - name: operator.v4.4
+    image: quay.io/openshift/clusterresourceoverride-rhel7-operator:4.4
+  - name: operand.v4.4
+    image: quay.io/openshift/clusterresourceoverride-rhel7:4.4
   customresourcedefinitions:
     owned:
       - description: Represents an instance of ClusterResourceOverride Admission Webhook


### PR DESCRIPTION
- Add `relatedImages' to the `ClusterServiceVersion` to support
disconnected install.
- Add both the operator and the operand image url
- `wait-for-deployment.sh` should fail if kubectl/oc binary is not
present instead of giving false message of retries.
