### PR TITLE
CSV: remove relatedImages

### DIFF
--- a/manifests/4.6/clusterresourceoverride-operator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/clusterresourceoverride-operator.v4.6.0.clusterserviceversion.yaml
@@ -16,11 +16,6 @@ metadata:
   name: clusterresourceoverride-operator.v4.6.0
   namespace: clusterresourceoverride-operator
 spec:
-  relatedImages:
-  - name: operator.v4.6
-    image: quay.io/openshift/clusterresourceoverride-rhel7-operator:4.6
-  - name: operand.v4.6
-    image: quay.io/openshift/clusterresourceoverride-rhel7:4.6
   customresourcedefinitions:
     owned:
       - description: Represents an instance of ClusterResourceOverride Admission Webhook


### PR DESCRIPTION
ART is intended to fill this in downstream; having it here already makes an invalid entry.

It's possible ART tooling could be made to replace this instead of add to it but it would certainly be simpler for us to remove this unless you know it's needed for something in CI.