### PR TITLE
Bug 1878163: Updating clusterresourceoverride-operator builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
 
 WORKDIR /go/src/github.com/openshift/cluster-resource-override-admission-operator
 COPY . .


### PR DESCRIPTION
Updating clusterresourceoverride-operator builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/990044f295fb1d5e238823902962dbcfa1c041c9/images/clusterresourceoverride-operator.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
