### PR TITLE
Match version with ART subst rule

### DIFF
--- a/manifests/4.6/clusterresourceoverride-operator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/clusterresourceoverride-operator.v4.6.0.clusterserviceversion.yaml
@@ -332,4 +332,4 @@ spec:
       name: Red Hat
   provider:
     name: Red Hat
-  version: 1.0.0
+  version: 4.6.0


### PR DESCRIPTION
The substitution rule expects to find version 4.6.0.
https://github.com/openshift/cluster-resource-override-admission-operator/blob/6ed6682c55a3a258c4d85741f7bc932595c21da4/manifests/art.yaml#L7-L8