### PR TITLE
bug 1904262: CSV: make version match what art.yaml looks for

### DIFF
--- a/manifests/4.6/clusterresourceoverride-operator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/clusterresourceoverride-operator.v4.6.0.clusterserviceversion.yaml
@@ -332,4 +332,4 @@ spec:
       name: Red Hat
   provider:
     name: Red Hat
-  version: 1.0.0
+  version: 4.6.0


### PR DESCRIPTION
This version needs to change each time it's released;
without this it will stay `1.0.0` forever and fail tests.

We will need the same thing for 4.7+ (though it needs to be `4.7.0` there).