### PR TITLE
Bug 1996213: Switch crd from v1beta1 to v1

### DIFF
--- a/Dockerfile.codegen
+++ b/Dockerfile.codegen
@@ -1,4 +1,4 @@
-FROM golang:1.15
+FROM golang:1.16
 
 WORKDIR /go/src/github.com/openshift/cluster-resource-override-admission-operator
 

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,10 +1,10 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.9 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.9 AS builder
 
 WORKDIR /go/src/github.com/openshift/cluster-resource-override-admission-operator
 COPY . .
 RUN make build
 
-FROM registry.svc.ci.openshift.org/ocp/4.9:base
+FROM registry.ci.openshift.org/ocp/4.9:base
 
 LABEL io.k8s.display-name="OpenShift ClusterResourceOverride Operator" \
       io.k8s.description="Manages Pod Resource(s)" \

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ include $(addprefix ./vendor/github.com/openshift/library-go/alpha-build-machine
 )
 
 # build image for ci
-CI_IMAGE_REGISTRY ?=registry.svc.ci.openshift.org
+CI_IMAGE_REGISTRY ?=registry.ci.openshift.org
 $(call build-image,clusterresourceoverride-operator,$(CI_IMAGE_REGISTRY)/autoscaling/clusterresourceoverride-operator,./images/ci/Dockerfile,.)
 
 REGISTRY_SETUP_BINARY := bin/registry-setup

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ status:
       resourceVersion: "78676"
       uid: 947ebfc5-c244-4621-acc3-c3117a10a97b
     mutatingWebhookConfigurationRef:
-      apiVersion: admissionregistration.k8s.io/v1beta1
+      apiVersion: admissionregistration.k8s.io/v1
       kind: MutatingWebhookConfiguration
       name: clusterresourceoverrides.admission.autoscaling.openshift.io
       resourceVersion: "127621"

--- a/artifacts/deploy/200_rbac.yaml
+++ b/artifacts/deploy/200_rbac.yaml
@@ -51,6 +51,17 @@ rules:
     - list
     - watch
 
+  # to have the power to read prioritylevelconfigurations
+  - apiGroups:
+    - flowcontrol.apiserver.k8s.io
+    resources:
+    - prioritylevelconfigurations
+    - flowschemas
+    verbs:
+    - get
+    - list
+    - watch
+
   # to have the power to manage configuration for admission webhook
   - apiGroups:
     - admissionregistration.k8s.io
@@ -157,6 +168,16 @@ rules:
     - update
     - patch
     - get
+
+  # to have the power to read prioritylevelconfigurations
+  - apiGroups:
+    - flowcontrol.apiserver.k8s.io
+    resources:
+    - prioritylevelconfigurations
+    verbs:
+    - get
+    - list
+    - watch
 
   # to have the power to watch secondary resources
   - apiGroups:

--- a/artifacts/deploy/200_rbac.yaml
+++ b/artifacts/deploy/200_rbac.yaml
@@ -174,6 +174,7 @@ rules:
     - flowcontrol.apiserver.k8s.io
     resources:
     - prioritylevelconfigurations
+    - flowschemas
     verbs:
     - get
     - list

--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.15 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.16 AS builder
 
 WORKDIR /go/src/github.com/openshift/cluster-resource-override-admission-operator
 
@@ -6,7 +6,7 @@ COPY . .
 
 RUN make build
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.ci.openshift.org/ocp/4.9:base
 
 COPY --from=builder /go/src/github.com/openshift/cluster-resource-override-admission-operator/bin/cluster-resource-override-admission-operator /usr/bin/
 

--- a/images/operator-registry/Dockerfile.registry.ci
+++ b/images/operator-registry/Dockerfile.registry.ci
@@ -6,14 +6,14 @@ FROM quay.io/operator-framework/upstream-registry-builder:v1.13.9 as registry-bu
 # We only need the binaries from this image.
 
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.15 AS operator-builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.15 AS operator-builder
 
 WORKDIR /
 COPY hack/ /scripts
 COPY manifests/ /manifests
 
 # build operator registry image
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.15
+FROM registry.ci.openshift.org/openshift/release:golang-1.15
 
 ARG VERSION
 

--- a/manifests/4.9/clusterresourceoverride-operator.v4.9.0.clusterserviceversion.yaml
+++ b/manifests/4.9/clusterresourceoverride-operator.v4.9.0.clusterserviceversion.yaml
@@ -137,6 +137,16 @@ spec:
             - update
             - patch
             - get
+        # Operator must have these privs so that it can grant them to the operand
+        - apiGroups:
+            - flowcontrol.apiserver.k8s.io
+          resources:
+            - flowschemas
+            - prioritylevelconfigurations
+          verbs:
+            - get
+            - list
+            - watch
 
         # to have the power to read configmaps in the kube-system namespace
         - apiGroups:

--- a/manifests/4.9/clusterresourceoverride.crd.yaml
+++ b/manifests/4.9/clusterresourceoverride.crd.yaml
@@ -1,18 +1,10 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterresourceoverrides.operator.autoscaling.openshift.io
 spec:
   group: operator.autoscaling.openshift.io
-  version: v1
-  versions:
-    - name: v1
-      served: true
-      storage: true
   scope: Cluster
-  subresources:
-    # status enables the status subresource.
-    status: {}
   names:
     plural: clusterresourceoverrides
     singular: clusterresourceoverride
@@ -20,36 +12,37 @@ spec:
     listKind: ClusterResourceOverrideList
     shortNames:
       - cro
-  validation:
-    openAPIV3Schema:
-      description: Allows cluster administrator to control the level of overcommit and manage container density on nodes.
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
           type: object
-          description: Spec for a ClusterResourceOverride.
+          x-kubernetes-preserve-unknown-fields: true
           properties:
-            podResourceOverride:
+            spec:
               type: object
-              description: Configuration for Pod resource overrides.
               properties:
-                spec:
+                podResourceOverride:
                   type: object
-                  description: Spec for Pod resource overrides.
                   properties:
-                    memoryRequestToLimitPercent:
-                      type: integer
-                      description: (optional, 1-100) If a container memory limit has been specified or defaulted, the memory request is overridden to this percentage of the limit.
-                      minimum: 1
-                      maximum: 100
-                    cpuRequestToLimitPercent:
-                      type: integer
-                      description: (optional, 1-100) If a container CPU limit has been specified or defaulted, the CPU request is overridden to this percentage of the limit.
-                      minimum: 1
-                      maximum: 100
-                    limitCPUToMemoryPercent:
-                      type: integer
-                      description: (optional, positive integer) If a container memory limit has been specified or defaulted, the CPU limit is overridden to a percentage of the memory limit, with a 100 percentage scaling 1Gi of RAM to equal 1 CPU core. This is processed prior to overriding CPU request (if configured).
-                      minimum: 0
-        status:
-          type: object
-          description: The status of the ClusterResourceOverride
+                    spec:
+                      type: object
+                      properties:
+                        memoryRequestToLimitPercent:
+                          type: integer
+                          minimum: 1
+                          maximum: 100
+                        cpuRequestToLimitPercent:
+                          type: integer
+                          minimum: 1
+                          maximum: 100
+                        limitCPUToMemoryPercent:
+                          type: integer
+                          minimum: 0
+            status:
+              type: object
+              description: The status of the ClusterResourceOverride

--- a/manifests/4.9/clusterresourceoverride.crd.yaml
+++ b/manifests/4.9/clusterresourceoverride.crd.yaml
@@ -3,6 +3,8 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterresourceoverrides.operator.autoscaling.openshift.io
 spec:
+  conversion:
+    strategy: None
   group: operator.autoscaling.openshift.io
   scope: Cluster
   names:
@@ -11,38 +13,45 @@ spec:
     kind: ClusterResourceOverride
     listKind: ClusterResourceOverrideList
     shortNames:
-      - cro
+    - cro
   versions:
-    - name: v1
-      served: true
-      storage: true
-      subresources:
-        status: {}
-      schema:
-        openAPIV3Schema:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-          properties:
-            spec:
-              type: object
-              properties:
-                podResourceOverride:
-                  type: object
-                  properties:
-                    spec:
-                      type: object
-                      properties:
-                        memoryRequestToLimitPercent:
-                          type: integer
-                          minimum: 1
-                          maximum: 100
-                        cpuRequestToLimitPercent:
-                          type: integer
-                          minimum: 1
-                          maximum: 100
-                        limitCPUToMemoryPercent:
-                          type: integer
-                          minimum: 0
-            status:
-              type: object
-              description: The status of the ClusterResourceOverride
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        description: Allows cluster administrator to control the level of overcommit and manage container density on nodes.
+        properties:
+          spec:
+            type: object
+            description: Spec for a ClusterResourceOverride.
+            properties:
+              podResourceOverride:
+                type: object
+                description: Configuration for Pod resource overrides.
+                properties:
+                  spec:
+                    type: object
+                    description: Spec for Pod resource overrides.
+                    properties:
+                      memoryRequestToLimitPercent:
+                        type: integer
+                        description: (optional, 1-100) If a container memory limit has been specified or defaulted, the memory request is overridden to this percentage of the limit.
+                        minimum: 1
+                        maximum: 100
+                      cpuRequestToLimitPercent:
+                        type: integer
+                        description: (optional, 1-100) If a container CPU limit has been specified or defaulted, the CPU request is overridden to this percentage of the limit.
+                        minimum: 1
+                        maximum: 100
+                      limitCPUToMemoryPercent:
+                        type: integer
+                        description: (optional, positive integer) If a container memory limit has been specified or defaulted, the CPU limit is overridden to a percentage of the memory limit, with a 100 percentage scaling 1Gi of RAM to equal 1 CPU core. This is processed prior to overriding CPU request (if configured).
+                        minimum: 0
+          status:
+            type: object
+            description: The status of the ClusterResourceOverride
+            x-kubernetes-preserve-unknown-fields: true

--- a/pkg/asset/daemonset.go
+++ b/pkg/asset/daemonset.go
@@ -67,7 +67,6 @@ func (d *daemonset) New() *appsv1.DaemonSet {
 							Args: []string{
 								"--secure-port=9400",
 								"--bind-address=127.0.0.1",
-								"--audit-log-path=-",
 								"--tls-cert-file=/var/serving-cert/tls.crt",
 								"--tls-private-key-file=/var/serving-cert/tls.key",
 								"--v=3",

--- a/pkg/asset/deployment.go
+++ b/pkg/asset/deployment.go
@@ -28,7 +28,7 @@ func (d *deployment) New() *appsv1.Deployment {
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
-			APIVersion: "extensions/v1beta1",
+			APIVersion: "extensions/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: values.Namespace,
@@ -60,7 +60,6 @@ func (d *deployment) New() *appsv1.Deployment {
 							ImagePullPolicy: corev1.PullAlways,
 							Args: []string{
 								"--secure-port=8443",
-								"--audit-log-path=-",
 								"--tls-cert-file=/var/serving-cert/tls.crt",
 								"--tls-private-key-file=/var/serving-cert/tls.key",
 								"--v=8",

--- a/pkg/asset/rbac.go
+++ b/pkg/asset/rbac.go
@@ -2,6 +2,7 @@ package asset
 
 import (
 	"fmt"
+
 	operatorruntime "github.com/openshift/cluster-resource-override-admission-operator/pkg/runtime"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -143,6 +144,21 @@ func (s *rbac) New() []*RBACItem {
 						Resources: []string{
 							"namespaces",
 							"limitranges",
+						},
+						Verbs: []string{
+							"get",
+							"list",
+							"watch",
+						},
+					},
+					// to give power to the operand to watch Namespace and LimitRange
+					{
+						APIGroups: []string{
+							"flowcontrol.apiserver.k8s.io",
+						},
+						Resources: []string{
+							"prioritylevelconfigurations",
+							"flowschemas",
 						},
 						Verbs: []string{
 							"get",

--- a/pkg/asset/webhookconfiguration.go
+++ b/pkg/asset/webhookconfiguration.go
@@ -92,7 +92,7 @@ func (m *mutatingWebhookConfiguration) New() *admissionregistrationv1.MutatingWe
 				TimeoutSeconds:          &timeoutSeconds,
 				SideEffects:             &sideEffects,
 				ReinvocationPolicy:      &reinvoke,
-				AdmissionReviewVersions: []string{"v1beta1", "v1"},
+				AdmissionReviewVersions: []string{"v1"},
 			},
 		},
 	}

--- a/pkg/asset/webhookconfiguration.go
+++ b/pkg/asset/webhookconfiguration.go
@@ -3,7 +3,7 @@ package asset
 import (
 	"fmt"
 
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -25,18 +25,18 @@ func (m *mutatingWebhookConfiguration) Name() string {
 	return fmt.Sprintf("%s.%s", m.values.AdmissionAPIResource, m.values.AdmissionAPIGroup)
 }
 
-func (m *mutatingWebhookConfiguration) New() *admissionregistrationv1beta1.MutatingWebhookConfiguration {
+func (m *mutatingWebhookConfiguration) New() *admissionregistrationv1.MutatingWebhookConfiguration {
 	url := fmt.Sprintf("https://localhost:9400/apis/%s/%s/%s", m.values.AdmissionAPIGroup, m.values.AdmissionAPIVersion, m.values.AdmissionAPIResource)
-	policy := admissionregistrationv1beta1.Fail
-	matchPolicy := admissionregistrationv1beta1.Equivalent
+	policy := admissionregistrationv1.Fail
+	matchPolicy := admissionregistrationv1.Equivalent
 	namespaceMatchLabelKey := fmt.Sprintf("%s.%s/enabled", m.values.AdmissionAPIResource, m.values.AdmissionAPIGroup)
 	timeoutSeconds := int32(5)
-	sideEffects := admissionregistrationv1beta1.SideEffectClassNone
-	reinvoke := admissionregistrationv1beta1.IfNeededReinvocationPolicy
-	return &admissionregistrationv1beta1.MutatingWebhookConfiguration{
+	sideEffects := admissionregistrationv1.SideEffectClassNone
+	reinvoke := admissionregistrationv1.IfNeededReinvocationPolicy
+	return &admissionregistrationv1.MutatingWebhookConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "MutatingWebhookConfiguration",
-			APIVersion: "admissionregistration.k8s.io/v1beta1",
+			APIVersion: "admissionregistration.k8s.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: m.Name(),
@@ -44,7 +44,7 @@ func (m *mutatingWebhookConfiguration) New() *admissionregistrationv1beta1.Mutat
 				m.values.OwnerLabelKey: m.values.OwnerLabelValue,
 			},
 		},
-		Webhooks: []admissionregistrationv1beta1.MutatingWebhook{
+		Webhooks: []admissionregistrationv1.MutatingWebhook{
 			{
 				Name: m.Name(),
 				NamespaceSelector: &metav1.LabelSelector{
@@ -63,19 +63,19 @@ func (m *mutatingWebhookConfiguration) New() *admissionregistrationv1beta1.Mutat
 					},
 				},
 				MatchPolicy: &matchPolicy,
-				ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
 					// CABundle will be injected at runtime
 					CABundle: nil,
 					URL:      &url,
 				},
-				Rules: []admissionregistrationv1beta1.RuleWithOperations{
+				Rules: []admissionregistrationv1.RuleWithOperations{
 					{
-						Operations: []admissionregistrationv1beta1.OperationType{
-							admissionregistrationv1beta1.Create,
-							admissionregistrationv1beta1.Update,
+						Operations: []admissionregistrationv1.OperationType{
+							admissionregistrationv1.Create,
+							admissionregistrationv1.Update,
 						},
 
-						Rule: admissionregistrationv1beta1.Rule{
+						Rule: admissionregistrationv1.Rule{
 							APIGroups: []string{
 								"",
 							},
@@ -88,10 +88,11 @@ func (m *mutatingWebhookConfiguration) New() *admissionregistrationv1beta1.Mutat
 						},
 					},
 				},
-				FailurePolicy:      &policy,
-				TimeoutSeconds:     &timeoutSeconds,
-				SideEffects:        &sideEffects,
-				ReinvocationPolicy: &reinvoke,
+				FailurePolicy:           &policy,
+				TimeoutSeconds:          &timeoutSeconds,
+				SideEffects:             &sideEffects,
+				ReinvocationPolicy:      &reinvoke,
+				AdmissionReviewVersions: []string{"v1beta1", "v1"},
 			},
 		},
 	}

--- a/pkg/clusterresourceoverride/internal/handlers/deploy.go
+++ b/pkg/clusterresourceoverride/internal/handlers/deploy.go
@@ -96,7 +96,7 @@ func (c *daemonSetHandler) Handle(context *ReconcileRequestContext, original *au
 
 func (c *daemonSetHandler) Ensure(ctx *ReconcileRequestContext, cro *autoscalingv1.ClusterResourceOverride) (current runtime.Object, accessor metav1.Object, err error) {
 	name := c.asset.NewMutatingWebhookConfiguration().Name()
-	if deleteErr := c.client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Delete(context.TODO(), name, metav1.DeleteOptions{}); deleteErr != nil && !k8serrors.IsNotFound(deleteErr) {
+	if deleteErr := c.client.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.TODO(), name, metav1.DeleteOptions{}); deleteErr != nil && !k8serrors.IsNotFound(deleteErr) {
 		err = fmt.Errorf("failed to delete MutatingWebhookConfiguration - %s", deleteErr.Error())
 		return
 	}

--- a/pkg/clusterresourceoverride/internal/handlers/webhook.go
+++ b/pkg/clusterresourceoverride/internal/handlers/webhook.go
@@ -31,7 +31,7 @@ func (w *webhookConfigurationHandler) Handle(context *ReconcileRequestContext, o
 	ensure := false
 
 	name := w.asset.NewMutatingWebhookConfiguration().Name()
-	object, err := w.lister.AdmissionRegistrationV1beta1MutatingWebhookConfigurationLister().Get(name)
+	object, err := w.lister.AdmissionRegistrationV1MutatingWebhookConfigurationLister().Get(name)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			handleErr = condition.NewInstallReadinessError(autoscalingv1.CertNotAvailable, err)

--- a/pkg/ensurer/webhookconfiguration.go
+++ b/pkg/ensurer/webhookconfiguration.go
@@ -2,7 +2,7 @@ package ensurer
 
 import (
 	"github.com/openshift/cluster-resource-override-admission-operator/pkg/dynamic"
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -16,14 +16,14 @@ type MutatingWebhookConfigurationEnsurer struct {
 	client dynamic.Ensurer
 }
 
-func (m *MutatingWebhookConfigurationEnsurer) Ensure(configuration *admissionregistrationv1beta1.MutatingWebhookConfiguration) (current *admissionregistrationv1beta1.MutatingWebhookConfiguration, err error) {
+func (m *MutatingWebhookConfigurationEnsurer) Ensure(configuration *admissionregistrationv1.MutatingWebhookConfiguration) (current *admissionregistrationv1.MutatingWebhookConfiguration, err error) {
 	unstructured, errGot := m.client.Ensure("mutatingwebhookconfigurations", configuration)
 	if errGot != nil {
 		err = errGot
 		return
 	}
 
-	current = &admissionregistrationv1beta1.MutatingWebhookConfiguration{}
+	current = &admissionregistrationv1.MutatingWebhookConfiguration{}
 	if conversionErr := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.UnstructuredContent(), current); conversionErr != nil {
 		err = conversionErr
 		return

--- a/pkg/secondarywatch/lister.go
+++ b/pkg/secondarywatch/lister.go
@@ -1,7 +1,7 @@
 package secondarywatch
 
 import (
-	admissionregistrationv1beta1 "k8s.io/client-go/listers/admissionregistration/v1beta1"
+	admissionregistrationv1 "k8s.io/client-go/listers/admissionregistration/v1"
 	listersappsv1 "k8s.io/client-go/listers/apps/v1"
 	listerscorev1 "k8s.io/client-go/listers/core/v1"
 )
@@ -15,7 +15,7 @@ type Lister struct {
 	service        listerscorev1.ServiceLister
 	secret         listerscorev1.SecretLister
 	serviceaccount listerscorev1.ServiceAccountLister
-	webhook        admissionregistrationv1beta1.MutatingWebhookConfigurationLister
+	webhook        admissionregistrationv1.MutatingWebhookConfigurationLister
 }
 
 func (l *Lister) CoreV1ConfigMapLister() listerscorev1.ConfigMapLister {
@@ -38,6 +38,6 @@ func (l *Lister) AppsV1DaemonSetLister() listersappsv1.DaemonSetLister {
 	return l.daemonset
 }
 
-func (l *Lister) AdmissionRegistrationV1beta1MutatingWebhookConfigurationLister() admissionregistrationv1beta1.MutatingWebhookConfigurationLister {
+func (l *Lister) AdmissionRegistrationV1MutatingWebhookConfigurationLister() admissionregistrationv1.MutatingWebhookConfigurationLister {
 	return l.webhook
 }

--- a/pkg/secondarywatch/start.go
+++ b/pkg/secondarywatch/start.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"reflect"
 
+	"time"
+
 	"github.com/openshift/cluster-resource-override-admission-operator/pkg/runtime"
 	"k8s.io/client-go/informers"
-	"time"
 )
 
 type Options struct {
@@ -37,7 +38,7 @@ func New(options *Options) (lister *Lister, startFunc StarterFunc) {
 	service := factory.Core().V1().Services()
 	secret := factory.Core().V1().Secrets()
 	serviceaccount := factory.Core().V1().ServiceAccounts()
-	webhook := factory.Admissionregistration().V1beta1().MutatingWebhookConfigurations()
+	webhook := factory.Admissionregistration().V1().MutatingWebhookConfigurations()
 
 	startFunc = func(enqueuer runtime.Enqueuer, shutdown context.Context) error {
 		handler := newResourceEventHandler(enqueuer)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -239,7 +239,7 @@ func TestClusterResourceOverrideAdmissionWithOptIn(t *testing.T) {
 	client := helper.NewClient(t, options.config)
 
 	f := &helper.PreCondition{Client: client.Kubernetes}
-	f.MustHaveAdmissionRegistrationV1beta1(t)
+	f.MustHaveAdmissionRegistrationV1(t)
 
 	// ensure we have the webhook up and running with the desired config
 	configuration := autoscalingv1.PodResourceOverrideSpec{
@@ -288,7 +288,7 @@ func TestClusterResourceOverrideAdmissionWithConfigurationChange(t *testing.T) {
 	client := helper.NewClient(t, options.config)
 
 	f := &helper.PreCondition{Client: client.Kubernetes}
-	f.MustHaveAdmissionRegistrationV1beta1(t)
+	f.MustHaveAdmissionRegistrationV1(t)
 
 	before := autoscalingv1.PodResourceOverrideSpec{
 		LimitCPUToMemoryPercent:     100,
@@ -356,7 +356,7 @@ func TestClusterResourceOverrideAdmissionWithCertRotation(t *testing.T) {
 	client := helper.NewClient(t, options.config)
 
 	f := &helper.PreCondition{Client: client.Kubernetes}
-	f.MustHaveAdmissionRegistrationV1beta1(t)
+	f.MustHaveAdmissionRegistrationV1(t)
 
 	configuration := autoscalingv1.PodResourceOverrideSpec{
 		LimitCPUToMemoryPercent:     50,
@@ -418,7 +418,7 @@ func TestClusterResourceOverrideAdmissionWithNoOptIn(t *testing.T) {
 	client := helper.NewClient(t, options.config)
 
 	f := &helper.PreCondition{Client: client.Kubernetes}
-	f.MustHaveAdmissionRegistrationV1beta1(t)
+	f.MustHaveAdmissionRegistrationV1(t)
 
 	configuration := autoscalingv1.PodResourceOverrideSpec{
 		LimitCPUToMemoryPercent:     200,

--- a/test/helper/precondition.go
+++ b/test/helper/precondition.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -19,7 +18,7 @@ type PreCondition struct {
 	Client kubernetes.Interface
 }
 
-func (f *PreCondition) MustHaveAdmissionRegistrationV1beta1(t *testing.T) {
+func (f *PreCondition) MustHaveAdmissionRegistrationV1(t *testing.T) {
 	apiGroupList := &metav1.APIGroupList{}
 	err := f.Client.Discovery().RESTClient().Get().AbsPath("/apis").Do(context.TODO()).Into(apiGroupList)
 	require.NoError(t, err, "fetching /apis")
@@ -36,23 +35,23 @@ func (f *PreCondition) MustHaveAdmissionRegistrationV1beta1(t *testing.T) {
 
 	require.NotNil(t, group, "admissionregistration.k8s.io API group not found in /apis discovery document")
 
-	t.Log("finding the admissionregistration.k8s.io/v1beta1 API group/version in the /apis discovery document")
+	t.Log("finding the admissionregistration.k8s.io/v1 API group/version in the /apis discovery document")
 	var version *metav1.GroupVersionForDiscovery
 	for _, v := range group.Versions {
-		if v.Version == admissionregistrationv1beta1.SchemeGroupVersion.Version {
+		if v.Version == admissionregistrationv1.SchemeGroupVersion.Version {
 			version = &v
 			break
 		}
 	}
 
-	require.NotNil(t, version, "admissionregistration.k8s.io/v1beta1 API group version not found in /apis discovery document")
+	require.NotNil(t, version, "admissionregistration.k8s.io/v1 API group version not found in /apis discovery document")
 }
 
 func (f *PreCondition) MustHaveClusterResourceOverrideAdmissionConfiguration(t *testing.T) {
 	t.Logf("fetching MutatingWebhookConfigurations %s", webhookName)
 
-	configuration, err := f.Client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(context.TODO(), webhookName, metav1.GetOptions{})
+	configuration, err := f.Client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.TODO(), webhookName, metav1.GetOptions{})
 
-	require.NoErrorf(t, err, "MutatingWebhookConfiguration %s resource not found in /apis/admissionregistration.k8s.io/v1beta1 discovery document", webhookName)
+	require.NoErrorf(t, err, "MutatingWebhookConfiguration %s resource not found in /apis/admissionregistration.k8s.io/v1 discovery document", webhookName)
 	require.NotNil(t, configuration)
 }


### PR DESCRIPTION
CRD `apiextensions.k8s.io/v1beta1` is being removed in 4.9 and so we must switch our CRD to `apiextensions.k8s.io/v1beta1` or the operator will break.

Conversion done on a 4.8 cluster via 
```
oc get crd clusterresourceoverrides.operator.autoscaling.openshift.io -o yaml
```
then stripping the `conditions` field and all `metadata` fields except `name`.

Also includes @rphillips' updates to other v1beta1 types and updates to base images, etc.