### PR TITLE
Bug 1987136: Declare supported arches in CSV

### DIFF
--- a/manifests/4.9/clusterresourceoverride-operator.v4.9.0.clusterserviceversion.yaml
+++ b/manifests/4.9/clusterresourceoverride-operator.v4.9.0.clusterserviceversion.yaml
@@ -13,6 +13,8 @@ metadata:
     healthIndex: B
     repository: https://github.com/openshift/cluster-resource-override-operator
     support: Red Hat
+  labels:
+    operatorframework.io/arch.amd64: supported
   name: clusterresourceoverride-operator.v4.9.0
   namespace: clusterresourceoverride-operator
 spec:


### PR DESCRIPTION
The OperatorHub currently assumes x86-only for any operators which do
not declare any such labels.  Declaring these explicitly should make the
current status more obvious in the code, and make it easier to correctly
add further architectures when conditions warrant.
