### PR TITLE
Bump version to 4.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GO_BUILD_BINDIR := bin
 GO_TEST_PACKAGES :=./pkg/... ./cmd/...
 
 KUBECTL = kubectl
-VERSION := 4.12
+VERSION := 4.13
 
 OPERATOR_NAMESPACE 			:= clusterresourceoverride-operator
 OPERATOR_DEPLOYMENT_NAME 	:= clusterresourceoverride-operator

--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -10,5 +10,5 @@ updates:
         replace: 'olm.skipRange: ">=4.3.0 <{FULL_VER}"'
   - file: "clusterresourceoverride-operator.package.yaml"
     update_list:
-      - search: "currentCSV: clusterresourceoverride-operator.v4.12.0"
+      - search: "currentCSV: clusterresourceoverride-operator.v4.13.0"
         replace: "currentCSV: clusterresourceoverride-operator.{FULL_VER}"

--- a/manifests/clusterresourceoverride-operator.package.yaml
+++ b/manifests/clusterresourceoverride-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: clusterresourceoverride
 channels:
   - name: stable
-    currentCSV: clusterresourceoverride-operator.v4.12.0
+    currentCSV: clusterresourceoverride-operator.v4.13.0

--- a/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
+++ b/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
@@ -6,8 +6,8 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional
     certifiedLevel: Primed
-    olm.skipRange: ">=4.3.0 <4.12.0"
-    containerImage: quay.io/openshift/clusterresourceoverride-rhel8-operator:4.12
+    olm.skipRange: ">=4.3.0 <4.13.0"
+    containerImage: quay.io/openshift/clusterresourceoverride-rhel8-operator:4.13
     createdAt: 2019/11/15
     description: An operator to manage the OpenShift ClusterResourceOverride Mutating Admission Webhook Server
     healthIndex: B
@@ -15,7 +15,7 @@ metadata:
     support: Red Hat
   labels:
     operatorframework.io/arch.amd64: supported
-  name: clusterresourceoverride-operator.v4.12.0
+  name: clusterresourceoverride-operator.v4.13.0
   namespace: clusterresourceoverride-operator
 spec:
   customresourcedefinitions:
@@ -290,7 +290,7 @@ spec:
                 serviceAccountName: clusterresourceoverride-operator
                 containers:
                   - name: clusterresourceoverride-operator
-                    image: quay.io/openshift/clusterresourceoverride-rhel8-operator:4.12
+                    image: quay.io/openshift/clusterresourceoverride-rhel8-operator:4.13
                     imagePullPolicy: Always
                     command:
                       - /usr/bin/cluster-resource-override-admission-operator
@@ -308,7 +308,7 @@ spec:
                           fieldRef:
                             fieldPath: metadata.namespace
                       - name: OPERAND_IMAGE
-                        value: quay.io/openshift/clusterresourceoverride-rhel8:4.12
+                        value: quay.io/openshift/clusterresourceoverride-rhel8:4.13
                       - name: OPERAND_VERSION
                         value: 1.0.0
                     ports:
@@ -347,10 +347,10 @@ spec:
     - efficiency
   labels:
     olm-owner-enterprise-app: clusterresourceoverride-operator
-    olm-status-descriptors: clusterresourceoverride-operator.v4.12.0
+    olm-status-descriptors: clusterresourceoverride-operator.v4.13.0
   maintainers:
     - email: support@redhat.com
       name: Red Hat
   provider:
     name: Red Hat
-  version: 4.12.0
+  version: 4.13.0

--- a/manifests/stable/image-references
+++ b/manifests/stable/image-references
@@ -6,8 +6,8 @@ spec:
   - name: clusterresourceoverride-rhel8-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/clusterresourceoverride-rhel8-operator:4.12
+      name: quay.io/openshift/clusterresourceoverride-rhel8-operator:4.13
   - name: clusterresourceoverride-rhel8
     from:
       kind: DockerImage
-      name: quay.io/openshift/clusterresourceoverride-rhel8:4.12
+      name: quay.io/openshift/clusterresourceoverride-rhel8:4.13


### PR DESCRIPTION
Operator [is currenty disabled](https://github.com/openshift/ocp-build-data/blob/openshift-4.13/images/clusterresourceoverride-operator.yml#L1) in 4.13 ART's config. It can be re-enabled once version is bumped