### PR TITLE
fix naming convention

### DIFF
--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -3,7 +3,7 @@ updates:
     update_list:
       # replace metadata.name value
       - search: "clusterresourceoverride-operator.v{MAJOR}.{MINOR}.0"
-        replace: "clusterresourceoverride-operator.{FULL_VER}"
+        replace: "clusterresourceoverride-operator.v{FULL_VER}"
       - search: "version: {MAJOR}.{MINOR}.0"
         replace: "version: {FULL_VER}"
       - search: 'olm.skipRange: ">=4.3.0 <{MAJOR}.{MINOR}.0"'


### PR DESCRIPTION
there is a warning reported in CVP check for 4.12
`Warning: Value : (clusterresourceoverride-operator.4.12.0-202211081106) csv.metadata.Name clusterresourceoverride-operator.4.12.0-202211081106 is not following the recommended naming convention: <operator-name>.v<semver> e.g. memcached-operator.v0.0.1`
http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-redhat-operator-bundle-image-validation-test/ose-clusterresourceoverride-operator-metadata-container-v4.12.0.202211081106.p0.g5ff6387.assembly.stream-1/dfafc43f-7d13-4a7e-ad35-132a2e03d9cc/operator-metadata-linting-bundle-image-output.txt
I think this could be a common issue, so pr against master can cherry-pick to 4.12 branch later.