### PR TITLE
add ppc64le arch label to CRO

### DIFF
--- a/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
+++ b/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
@@ -15,6 +15,7 @@ metadata:
     support: Red Hat
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
   name: clusterresourceoverride-operator.v4.13.0
   namespace: clusterresourceoverride-operator
 spec:


### PR DESCRIPTION
Add ppc64le arch label to make CRO operator visible in OperatorHub on ppc64le platform.