### PR TITLE
Added s390x architecture label to operator CSV

### DIFF
--- a/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
+++ b/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
@@ -15,6 +15,7 @@ metadata:
     support: Red Hat
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.s390x: supported
   name: clusterresourceoverride-operator.v4.13.0
   namespace: clusterresourceoverride-operator
 spec:


### PR DESCRIPTION
This PR adds a label for platform / architecture *s390x* to the operator CSV. See the following Jira issue for reference: https://issues.redhat.com/browse/OCPBUGS-7075