### PR TITLE
OCPBUGS-33577: Fixes webhook configuration to be correctly configured as an extension API server

### DIFF
--- a/artifacts/deploy/200_rbac.yaml
+++ b/artifacts/deploy/200_rbac.yaml
@@ -88,14 +88,6 @@ rules:
     - list
     - watch
 
-  # to grant the operand power to create admission reviews
-  - apiGroups:
-    - autoscaling.openshift.io
-    resources:
-    - clusterresourceoverride
-    verbs:
-    - create
-
   # default for an aggregated apiserver
   - apiGroups:
     - admissionregistration.k8s.io
@@ -132,17 +124,7 @@ rules:
     verbs:
     - create
 
-  # to grant power to the operand to use hostnetwork-v2 scc
-  - apiGroups:
-    - security.openshift.io
-    resources:
-    - securitycontextconstraints
-    verbs:
-    - use
-    resourceNames:
-    - hostnetwork-v2
-
-  # to grant power to the operand to allow anonymous access to the admission server
+  # to grant power for the operand to create admission reviews
   - apiGroups:
     - admission.autoscaling.openshift.io
     resources:

--- a/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
+++ b/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
@@ -220,14 +220,6 @@ spec:
             - list
             - watch
 
-        # to grant the operand power to create admission reviews
-        - apiGroups:
-            - autoscaling.openshift.io
-          resources:
-            - clusterresourceoverride
-          verbs:
-            - create
-
         # default for an aggregated apiserver
         - apiGroups:
             - admissionregistration.k8s.io
@@ -264,17 +256,7 @@ spec:
           verbs:
             - create
 
-        # to grant power to the operand to use hostnetwork-v2 scc
-        - apiGroups:
-            - security.openshift.io
-          resources:
-            - securitycontextconstraints
-          verbs:
-            - use
-          resourceNames:
-            - hostnetwork-v2
-
-        # to grant power to the operand to allow anonymous access to the admission server
+        # to grant power for the operand to create admission reviews
         - apiGroups:
             - admission.autoscaling.openshift.io
           resources:

--- a/pkg/asset/apiservice.go
+++ b/pkg/asset/apiservice.go
@@ -30,8 +30,10 @@ func (a *apiservice) New() *apiregistrationv1.APIService {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: a.Name(),
 			Labels: map[string]string{
-				a.values.OwnerLabelKey:   a.values.OwnerLabelValue,
-				AutoRegisterManagedLabel: "onstart",
+				a.values.OwnerLabelKey: a.values.OwnerLabelValue,
+			},
+			Annotations: map[string]string{
+				"service.alpha.openshift.io/inject-cabundle": "true",
 			},
 		},
 		Spec: apiregistrationv1.APIServiceSpec{

--- a/pkg/asset/daemonset.go
+++ b/pkg/asset/daemonset.go
@@ -52,7 +52,6 @@ func (d *daemonset) New() *appsv1.DaemonSet {
 					},
 				},
 				Spec: corev1.PodSpec{
-					HostNetwork: true,
 					NodeSelector: map[string]string{
 						"node-role.kubernetes.io/master": "",
 					},
@@ -67,7 +66,6 @@ func (d *daemonset) New() *appsv1.DaemonSet {
 							},
 							Args: []string{
 								"--secure-port=9400",
-								"--bind-address=127.0.0.1",
 								"--tls-cert-file=/var/serving-cert/tls.crt",
 								"--tls-private-key-file=/var/serving-cert/tls.key",
 								"--v=3",
@@ -81,8 +79,6 @@ func (d *daemonset) New() *appsv1.DaemonSet {
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 9400,
-									HostPort:      9400,
-									Protocol:      corev1.ProtocolTCP,
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{

--- a/pkg/asset/rbac.go
+++ b/pkg/asset/rbac.go
@@ -51,7 +51,7 @@ func (s *rbac) New() []*RBACItem {
 					APIVersion: "v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      s.values.Name,
+					Name:      s.values.ServiceAccountName,
 					Namespace: s.values.Namespace,
 				},
 			},
@@ -96,10 +96,10 @@ func (s *rbac) New() []*RBACItem {
 				Rules: []rbacv1.PolicyRule{
 					{
 						APIGroups: []string{
-							"autoscaling.openshift.io",
+							s.values.AdmissionAPIGroup,
 						},
 						Resources: []string{
-							s.values.Name,
+							s.values.AdmissionAPIResource,
 						},
 						Verbs: []string{
 							"create",
@@ -212,113 +212,6 @@ func (s *rbac) New() []*RBACItem {
 				},
 				Subjects: []rbacv1.Subject{
 					thisOperatorServiceAccount,
-				},
-			},
-		},
-
-		// so that daemonset pods can use hostnetwork
-		{
-			Resource: "roles",
-			Object: &rbacv1.Role{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Role",
-					APIVersion: apiVersion,
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("%s-scc-hostnetwork-use", s.values.Name),
-					Namespace: s.values.Namespace,
-					Labels:    commonLabels,
-				},
-				Rules: []rbacv1.PolicyRule{
-					{
-						APIGroups: []string{
-							"security.openshift.io",
-						},
-						Resources: []string{
-							"securitycontextconstraints",
-						},
-						Verbs: []string{
-							"use",
-						},
-						ResourceNames: []string{
-							"hostnetwork-v2",
-						},
-					},
-				},
-			},
-		},
-		{
-			Resource: "rolebindings",
-			Object: &rbacv1.RoleBinding{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "RoleBinding",
-					APIVersion: apiVersion,
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("%s-scc-hostnetwork-use", s.values.Name),
-					Namespace: s.values.Namespace,
-					Labels:    commonLabels,
-				},
-				RoleRef: rbacv1.RoleRef{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "Role",
-					Name:     fmt.Sprintf("%s-scc-hostnetwork-use", s.values.Name),
-				},
-				Subjects: []rbacv1.Subject{
-					thisOperatorServiceAccount,
-				},
-			},
-		},
-
-		// so that kube-apiserver can directly call the webhook server
-		{
-			Resource: "clusterroles",
-			Object: &rbacv1.ClusterRole{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "ClusterRole",
-					APIVersion: apiVersion,
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   fmt.Sprintf("%s-anonymous-access", s.values.Name),
-					Labels: commonLabels,
-				},
-				Rules: []rbacv1.PolicyRule{
-					{
-						APIGroups: []string{
-							s.values.AdmissionAPIGroup,
-						},
-						Resources: []string{
-							s.values.AdmissionAPIResource,
-						},
-						Verbs: []string{
-							"create",
-						},
-					},
-				},
-			},
-		},
-		{
-			Resource: "clusterrolebindings",
-			Object: &rbacv1.ClusterRoleBinding{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "ClusterRoleBinding",
-					APIVersion: apiVersion,
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   fmt.Sprintf("%s-anonymous-access", s.values.Name),
-					Labels: commonLabels,
-				},
-				RoleRef: rbacv1.RoleRef{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "ClusterRole",
-					Name:     fmt.Sprintf("%s-anonymous-access", s.values.Name),
-				},
-				Subjects: []rbacv1.Subject{
-					{
-						APIGroup: "rbac.authorization.k8s.io",
-						Kind:     "User",
-						Name:     "system:anonymous",
-					},
 				},
 			},
 		},

--- a/pkg/asset/service.go
+++ b/pkg/asset/service.go
@@ -49,7 +49,7 @@ func (s *service) New() *corev1.Service {
 			Ports: []corev1.ServicePort{
 				{
 					Port:       443,
-					TargetPort: intstr.FromInt(8443),
+					TargetPort: intstr.FromInt(9400),
 				},
 			},
 		},

--- a/pkg/clusterresourceoverride/internal/handlers/apiservice.go
+++ b/pkg/clusterresourceoverride/internal/handlers/apiservice.go
@@ -42,8 +42,6 @@ func (a *apiServiceHandler) Handle(ctx *ReconcileRequestContext, original *autos
 
 		// No APIService object
 		object := a.asset.APIService().New()
-		object.Spec.CABundle = ctx.GetBundle().ServingCertCA
-		ctx.ControllerSetter().Set(object, original)
 
 		apiservice, err := a.ensurer.Ensure(object)
 		if err != nil {

--- a/pkg/clusterresourceoverride/internal/handlers/webhook.go
+++ b/pkg/clusterresourceoverride/internal/handlers/webhook.go
@@ -45,11 +45,6 @@ func (w *webhookConfigurationHandler) Handle(context *ReconcileRequestContext, o
 		desired := w.asset.NewMutatingWebhookConfiguration().New()
 		context.ControllerSetter().Set(desired, original)
 
-		servingCertCA := context.GetBundle().ServingCertCA
-		for i := range desired.Webhooks {
-			desired.Webhooks[i].ClientConfig.CABundle = servingCertCA
-		}
-
 		webhook, err := w.dynamic.Ensure(desired)
 		if err != nil {
 			handleErr = condition.NewInstallReadinessError(autoscalingv1.CertNotAvailable, err)

--- a/pkg/clusterresourceoverride/internal/reconciler/reconciler.go
+++ b/pkg/clusterresourceoverride/internal/reconciler/reconciler.go
@@ -29,10 +29,10 @@ func NewReconciler(options *handlers.Options) *reconciler {
 		handlers.NewAvailabilityHandler(options),
 		handlers.NewValidationHandler(options),
 		handlers.NewConfigurationHandler(options),
-		handlers.NewCertGenerationHandler(options),
-		handlers.NewCertReadyHandler(options),
+		handlers.NewServiceHandler(options),
 		handlers.NewDaemonSetHandler(options),
 		handlers.NewDeploymentReadyHandler(options),
+		handlers.NewAPIServiceHandler(options),
 		handlers.NewWebhookConfigurationHandlerHandler(options),
 		handlers.NewAvailabilityHandler(options),
 	}

--- a/pkg/operator/run.go
+++ b/pkg/operator/run.go
@@ -2,10 +2,13 @@ package operator
 
 import (
 	"fmt"
-	"github.com/openshift/cluster-resource-override-admission-operator/pkg/secondarywatch"
-	"k8s.io/klog/v2"
 	"net/http"
 	"time"
+
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/secondarywatch"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
 	"github.com/openshift/cluster-resource-override-admission-operator/pkg/clusterresourceoverride"
 	"github.com/openshift/cluster-resource-override-admission-operator/pkg/controller"
@@ -52,6 +55,7 @@ func (r *runner) Run(config *Config, errorCh chan<- error) {
 	}
 
 	context := runtime.NewOperandContext(config.Name, config.Namespace, DefaultCR, config.OperandImage, config.OperandVersion)
+	apiregistrationv1.AddToScheme(scheme.Scheme)
 
 	// create lister(s) for secondary resources
 	lister, starter := secondarywatch.New(&secondarywatch.Options{


### PR DESCRIPTION
This PR correctly fixes the operator to configure the webhook server as a proper aggregated extension API server. Previously, the webhook was directly calling the CRO server and hence we "required" `system:anonymous` cluster role and role bindings for the server. The extension apiserver now can validate that the user/group retrieved from the headers are authorized to execute the given request.