### PR TITLE
PODAUTO-189: PODAUTO-190:  Run CRO as a deployment and allow admins to scale and control where they run on

### DIFF
--- a/artifacts/deploy/200_rbac.yaml
+++ b/artifacts/deploy/200_rbac.yaml
@@ -192,6 +192,7 @@ rules:
     - patch
     - list
     - watch
+    - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/artifacts/example/deployment-overrides-specified.yaml
+++ b/artifacts/example/deployment-overrides-specified.yaml
@@ -1,0 +1,19 @@
+apiVersion: operator.autoscaling.openshift.io/v1
+kind: ClusterResourceOverride
+metadata:
+  name: cluster
+spec:
+  podResourceOverride:
+    spec:
+      memoryRequestToLimitPercent: 50
+      cpuRequestToLimitPercent: 25
+      limitCPUToMemoryPercent: 200
+  deploymentOverrides:
+    replicas: 1
+    nodeSelector:
+      node-role.kubernetes.io/worker: ""
+    tolerations:
+    - key: "key"
+      operator: "Equal"
+      value: "value"
+      effect: "NoSchedule"

--- a/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
+++ b/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
@@ -133,6 +133,7 @@ spec:
             - patch
             - list
             - watch
+            - delete
         serviceAccountName: clusterresourceoverride-operator
       clusterPermissions:
       - rules:

--- a/manifests/stable/clusterresourceoverride.crd.yaml
+++ b/manifests/stable/clusterresourceoverride.crd.yaml
@@ -54,6 +54,35 @@ spec:
                         type: integer
                         description: (optional, positive integer) If a container memory limit has been specified or defaulted, the CPU limit is overridden to a percentage of the memory limit, with a 100 percentage scaling 1Gi of RAM to equal 1 CPU core. This is processed prior to overriding CPU request (if configured).
                         minimum: 0
+              deploymentOverrides:
+                type: object
+                description: Deployment overrides for ClusterResourceOverrides.
+                properties:
+                  nodeSelector:
+                    type: object
+                    description: (optional) NodeSelector to apply to ClusterResourceOverrides deployments.
+                    additionalProperties:
+                      type: string
+                  tolerations:
+                    type: array
+                    description: (optional) Tolerations to apply to ClusterResourceOverrides deployments.
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        value:
+                          type: string
+                        effect:
+                          type: string
+                        tolerationSeconds:
+                          type: integer
+                  replicas:
+                    type: integer
+                    description: (optional) Number of replicas for ClusterResourceOverrides deployments. This number must not exceed the number of nodes that can accommodate the replicas, considering tolerations, and node selectors.
+                    minimum: 0
           status:
             type: object
             description: The status of the ClusterResourceOverride

--- a/pkg/apis/autoscaling/v1/override.go
+++ b/pkg/apis/autoscaling/v1/override.go
@@ -44,9 +44,17 @@ func (in *PodResourceOverrideSpec) Validate() error {
 }
 
 func (in *PodResourceOverrideSpec) Hash() string {
-	value := fmt.Sprintf("%s", in)
+	value := in.String()
 
 	writer := sha256.New()
 	writer.Write([]byte(value))
 	return hex.EncodeToString(writer.Sum(nil))
+}
+
+func (in *DeploymentOverrides) Validate() error {
+	if in.Replicas != nil && *in.Replicas < 0 {
+		return errors.New("invalid value for Replicas, must be a positive value")
+	}
+
+	return nil
 }

--- a/pkg/apis/autoscaling/v1/override_types.go
+++ b/pkg/apis/autoscaling/v1/override_types.go
@@ -61,6 +61,8 @@ type ClusterResourceOverride struct {
 
 type ClusterResourceOverrideSpec struct {
 	PodResourceOverride PodResourceOverride `json:"podResourceOverride"`
+	// +optional
+	DeploymentOverrides DeploymentOverrides `json:"deploymentOverrides,omitempty"`
 }
 
 type ClusterResourceOverrideStatus struct {
@@ -118,6 +120,23 @@ type ClusterResourceOverrideResources struct {
 type PodResourceOverride struct {
 	metav1.TypeMeta `json:",inline"`
 	Spec            PodResourceOverrideSpec `json:"spec,omitempty"`
+}
+
+// DeploymentOverrides defines fields that can be overridden for a given deployment.
+type DeploymentOverrides struct {
+	// Override the NodeSelector for the deployment's pods. This allows, for example, for the ClusterResourceOverride
+	// to be run on non-master nodes.
+	// +optional
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
+	// Override the Tolerations of the deployment's pods. This allows, for example, for the ClusterResourceOverride
+	// to be run on non-master nodes with a specific taint.
+	// +optional
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+
+	// Override the number of replicas for the deployment.
+	// +optional
+	Replicas *int32 `json:"replicas,omitempty"`
 }
 
 // PodResourceOverrideSpec is the configuration for the ClusterResourceOverride

--- a/pkg/clusterresourceoverride/controller.go
+++ b/pkg/clusterresourceoverride/controller.go
@@ -73,8 +73,8 @@ func New(options *Options) (c controller.Interface, e operatorruntime.Enqueuer, 
 	// setup operand asset
 	operandAsset := asset.New(options.RuntimeContext)
 
-	// initialize install strategy, we use daemonset
-	d := deploy.NewDaemonSetInstall(options.Lister.AppsV1DaemonSetLister(), options.RuntimeContext, operandAsset, ensurer.NewDaemonSetEnsurer(options.Client.Dynamic))
+	// initialize install strategy, we use deployment
+	d := deploy.NewDeploymentInstall(options.Lister.AppsV1DeploymentLister(), options.RuntimeContext, operandAsset, ensurer.NewDeploymentEnsurer(options.Client.Dynamic))
 
 	reconciler := reconciler.NewReconciler(&handlers.Options{
 		OperandContext:  options.RuntimeContext,

--- a/pkg/clusterresourceoverride/internal/handlers/validation.go
+++ b/pkg/clusterresourceoverride/internal/handlers/validation.go
@@ -16,9 +16,14 @@ type validationHandler struct {
 func (c *validationHandler) Handle(context *ReconcileRequestContext, original *autoscalingv1.ClusterResourceOverride) (current *autoscalingv1.ClusterResourceOverride, result controllerreconciler.Result, handleErr error) {
 	current = original
 
-	validationErr := original.Spec.PodResourceOverride.Spec.Validate()
-	if validationErr != nil {
-		handleErr = condition.NewInstallReadinessError(autoscalingv1.InvalidParameters, validationErr)
+	podResourceOverrideValidationErr := original.Spec.PodResourceOverride.Spec.Validate()
+	if podResourceOverrideValidationErr != nil {
+		handleErr = condition.NewInstallReadinessError(autoscalingv1.InvalidParameters, podResourceOverrideValidationErr)
+	}
+
+	deploymentOverridesValidationErr := original.Spec.DeploymentOverrides.Validate()
+	if deploymentOverridesValidationErr != nil {
+		handleErr = condition.NewInstallReadinessError(autoscalingv1.InvalidParameters, deploymentOverridesValidationErr)
 	}
 
 	return

--- a/pkg/clusterresourceoverride/internal/reconciler/reconciler.go
+++ b/pkg/clusterresourceoverride/internal/reconciler/reconciler.go
@@ -30,7 +30,7 @@ func NewReconciler(options *handlers.Options) *reconciler {
 		handlers.NewValidationHandler(options),
 		handlers.NewConfigurationHandler(options),
 		handlers.NewServiceHandler(options),
-		handlers.NewDaemonSetHandler(options),
+		handlers.NewDeploymentHandler(options),
 		handlers.NewDeploymentReadyHandler(options),
 		handlers.NewAPIServiceHandler(options),
 		handlers.NewWebhookConfigurationHandlerHandler(options),


### PR DESCRIPTION
~~For now only, CRD changes only allow `nodeSelector` to be applied to the deployment in order to influence pod scheduling. Example in `artifacts/example/node-selector-applied.yaml`.~~

~~Also, should the `nodeSelector` (+ `affinity`?) be placed somewhere else that's not in `podResourceOverride.spec`? Maybe in a new field?~~
Converts DaemonSet to Deployment.

Modifies CRD to include `deploymentOverrides` to override `nodeSelector` and `tolerations` for pod specs and `replicas` for deployment spec.

Also adds anti-affinity so that two pods do not schedule on the same node.