### PR TITLE
PODAUTO-202: Update ocp/builder images to openshift/release images

### DIFF
--- a/Dockerfile.codegen
+++ b/Dockerfile.codegen
@@ -1,4 +1,4 @@
-FROM golang:1.16
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17
 
 WORKDIR /go/src/github.com/openshift/cluster-resource-override-admission-operator
 
@@ -10,6 +10,8 @@ COPY boilerplate.go.txt boilerplate.go.txt
 
 # To avoid running into the following issue.
 # /bin/sh: 1: ./vendor/k8s.io/code-generator/generate-internal-groups.sh: Permission denied
-RUN chmod a+x vendor/k8s.io/code-generator/generate-internal-groups.sh
+
+# TODO(macao): Remove this old form of code-generation once we upgrade to operator-sdk
+RUN chmod a+x vendor/k8s.io/code-generator/kube_codegen.sh
 
 RUN make codegen-internal

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17 AS builder
 
 WORKDIR /go/src/github.com/openshift/cluster-resource-override-admission-operator
 COPY . .

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 
 WORKDIR /go/src/github.com/openshift/cluster-resource-override-admission-operator
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ GO_BUILD_BINDIR := bin
 GO_TEST_PACKAGES :=./pkg/... ./cmd/...
 
 KUBECTL = kubectl
+CONTAINER_ENGINE ?= docker
 VERSION := 4.17
 
 OPERATOR_NAMESPACE 			:= clusterresourceoverride-operator
@@ -43,12 +44,16 @@ REGISTRY_SETUP_BINARY := bin/registry-setup
 $(REGISTRY_SETUP_BINARY): GO_BUILD_PACKAGES =./test/registry-setup/...
 $(REGISTRY_SETUP_BINARY): build
 
+BUILD_CMD := $(if $(filter $(CONTAINER_ENGINE),buildah),$(CONTAINER_ENGINE) bud,$(CONTAINER_ENGINE) build) -t $(DEV_IMAGE_REGISTRY):$(IMAGE_TAG) -f ./images/dev/Dockerfile.dev .
+DEV_IMAGE_REGISTRY ?= quay.io/redhat
+IMAGE_TAG ?= dev
+
 # build image for dev use.
 dev-image:
-	docker build -t $(DEV_IMAGE_REGISTRY):$(IMAGE_TAG) -f ./images/dev/Dockerfile.dev .
+	$(BUILD_CMD)
 
 dev-push:
-	docker push $(DEV_IMAGE_REGISTRY):$(IMAGE_TAG)
+	$(CONTAINER_ENGINE) push $(DEV_IMAGE_REGISTRY):$(IMAGE_TAG)
 
 .PHONY: vendor
 vendor:

--- a/Makefile
+++ b/Makefile
@@ -12,19 +12,25 @@ GO=GO111MODULE=on GOFLAGS=-mod=vendor go
 GO_BUILD_BINDIR := bin
 GO_TEST_PACKAGES :=./pkg/... ./cmd/...
 
-KUBECTL = kubectl
-CONTAINER_ENGINE ?= docker
-VERSION := 4.17
+KUBECTL ?= kubectl
+CONTAINER_ENGINE ?= podman
+IMAGE_BUILDER ?= $(CONTAINER_ENGINE) # can support podman, docker, and buildah
+IMAGE_VERSION := 4.17
 
 OPERATOR_NAMESPACE 			:= clusterresourceoverride-operator
 OPERATOR_DEPLOYMENT_NAME 	:= clusterresourceoverride-operator
 
-export OLD_OPERATOR_IMAGE_URL_IN_CSV 	= quay.io/openshift/clusterresourceoverride-rhel8-operator:$(VERSION)
-export OLD_OPERAND_IMAGE_URL_IN_CSV 	= quay.io/openshift/clusterresourceoverride-rhel8:$(VERSION)
+export OLD_OPERATOR_IMAGE_URL_IN_CSV 	= quay.io/openshift/clusterresourceoverride-rhel8-operator:$(IMAGE_VERSION)
+export OLD_OPERAND_IMAGE_URL_IN_CSV 	= quay.io/openshift/clusterresourceoverride-rhel8:$(IMAGE_VERSION)
 export CSV_FILE_PATH_IN_REGISTRY_IMAGE 	= /manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
 
-LOCAL_OPERATOR_IMAGE	?= quay.io/redhat/clusterresourceoverride-operator:latest
-LOCAL_OPERAND_IMAGE 	?= quay.io/redhat/clusterresourceoverride:latest
+OPERATOR_IMAGE_TAG_BASE ?= quay.io/redhat/clusterresourceoverride-operator
+OPERAND_IMAGE_TAG_BASE ?= quay.io/redhat/clusterresourceoverride
+
+LOCAL_OPERATOR_IMAGE ?= $(OPERATOR_IMAGE_TAG_BASE):$(IMAGE_VERSION)
+LOCAL_OPERAND_IMAGE ?= $(OPERAND_IMAGE_TAG_BASE):$(IMAGE_VERSION)
+LOCAL_OPERATOR_REGISTRY_IMAGE ?= $(OPERATOR_IMAGE_TAG_BASE)-registry:$(IMAGE_VERSION)
+
 export LOCAL_OPERATOR_IMAGE
 export LOCAL_OPERAND_IMAGE
 export LOCAL_OPERATOR_REGISTRY_IMAGE
@@ -44,16 +50,12 @@ REGISTRY_SETUP_BINARY := bin/registry-setup
 $(REGISTRY_SETUP_BINARY): GO_BUILD_PACKAGES =./test/registry-setup/...
 $(REGISTRY_SETUP_BINARY): build
 
-BUILD_CMD := $(if $(filter $(CONTAINER_ENGINE),buildah),$(CONTAINER_ENGINE) bud,$(CONTAINER_ENGINE) build) -t $(DEV_IMAGE_REGISTRY):$(IMAGE_TAG) -f ./images/dev/Dockerfile.dev .
-DEV_IMAGE_REGISTRY ?= quay.io/redhat
-IMAGE_TAG ?= dev
+# build local image for dev use.
+local-image:
+	$(IMAGE_BUILDER) build -t $(LOCAL_OPERATOR_IMAGE) -f ./images/dev/Dockerfile.dev .
 
-# build image for dev use.
-dev-image:
-	$(BUILD_CMD)
-
-dev-push:
-	$(CONTAINER_ENGINE) push $(DEV_IMAGE_REGISTRY):$(IMAGE_TAG)
+local-push:
+	$(IMAGE_BUILDER) push $(LOCAL_OPERATOR_IMAGE)
 
 .PHONY: vendor
 vendor:
@@ -86,20 +88,23 @@ operator-registry-deploy-ci: operator-registry-generate operator-registry-deploy
 
 # TODO: Use alpha-build-machinery for codegen
 PKG=github.com/openshift/cluster-resource-override-admission-operator
-CODEGEN_INTERNAL:=./vendor/k8s.io/code-generator/generate-internal-groups.sh
+CODEGEN_INTERNAL:=./vendor/k8s.io/code-generator/kube_codegen.sh
 
 codegen:
-	docker build -t cro:codegen -f Dockerfile.codegen .
-	docker run --name cro-codegen cro:codegen /bin/true
-	docker cp cro-codegen:/go/src/github.com/openshift/cluster-resource-override-admission-operator/pkg/generated/. ./pkg/generated
-	docker cp cro-codegen:/go/src/github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/. ./pkg/apis
-	docker rm cro-codegen
+	$(IMAGE_BUILDER) build -t cro:codegen -f Dockerfile.codegen .
+	$(CONTAINER_ENGINE) run --name cro-codegen cro:codegen /bin/true
+	$(CONTAINER_ENGINE) cp cro-codegen:/go/src/github.com/openshift/cluster-resource-override-admission-operator/pkg/generated/. ./pkg/generated
+	$(CONTAINER_ENGINE) cp cro-codegen:/go/src/github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/. ./pkg/apis
+	$(CONTAINER_ENGINE) rm cro-codegen
 
 codegen-internal: export GO111MODULE := off
 codegen-internal:
 	mkdir -p vendor/k8s.io/code-generator/hack
 	cp boilerplate.go.txt vendor/k8s.io/code-generator/hack/boilerplate.go.txt
 	$(CODEGEN_INTERNAL) deepcopy,conversion,client,lister,informer $(PKG)/pkg/generated $(PKG)/pkg/apis $(PKG)/pkg/apis "autoscaling:v1"
+
+deploy-local: DEPLOY_MODE := local
+deploy-local: deploy
 
 # deploy the operator using kube manifests (no OLM)
 deploy: KUBE_MANIFESTS_SOURCE := "$(ARTIFACTS)/deploy"
@@ -117,6 +122,9 @@ deploy:
 	./hack/update-image-url.sh "$(CONFIGMAP_ENV_FILE)" "$(DEPLOYMENT_YAML)"
 
 	$(KUBECTL) apply -n $(OPERATOR_NAMESPACE) -f $(KUBE_MANIFESTS_DIR)
+
+undeploy-local: delete-test-pod delete-cro-cr
+	$(KUBECTL) delete -f $(KUBE_MANIFESTS_DIR)
 
 # run e2e test(s)
 e2e:
@@ -174,12 +182,12 @@ operator-registry-deploy: bin/yaml2json
 
 
 # build operator registry image for ci locally (used for local e2e test only)
-# local e2e test is done exactly the same way as ci with the exception that
+# local e2e test is done exactly the same way as ci withoperator-registry-image the exception that
 # in ci the operator registry image is built by ci agent.
 # on the other hand, in local mode, we need to build the image.
 operator-registry-image-ci:
-	docker build --build-arg VERSION=$(VERSION) -t $(LOCAL_OPERATOR_REGISTRY_IMAGE) -f images/operator-registry/Dockerfile.registry.ci .
-	docker push $(LOCAL_OPERATOR_REGISTRY_IMAGE)
+	$(IMAGE_BUILDER) build --build-arg VERSION=$(IMAGE_VERSION) -t $(LOCAL_OPERATOR_REGISTRY_IMAGE) -f images/operator-registry/Dockerfile.registry.ci .
+	$(IMAGE_BUILDER) push $(LOCAL_OPERATOR_REGISTRY_IMAGE)
 
 # build and push the OLM manifests for this operator into an operator-registry image.
 # this builds an image with the generated database, (unlike image used for ci)
@@ -193,5 +201,23 @@ operator-registry-image:
 	sed "s,$(OLD_OPERATOR_IMAGE_URL_IN_CSV),$(LOCAL_OPERATOR_IMAGE),g" -i "$(CSV_FILE)"
 	sed "s,$(OLD_OPERAND_IMAGE_URL_IN_CSV),$(LOCAL_OPERAND_IMAGE),g" -i "$(CSV_FILE)"
 
-	docker build --build-arg MANIFEST_LOCATION=$(MANIFESTS_DIR) -t $(LOCAL_OPERATOR_REGISTRY_IMAGE) -f images/operator-registry/Dockerfile.registry .
-	docker push $(LOCAL_OPERATOR_REGISTRY_IMAGE)
+	$(IMAGE_BUILDER) build --build-arg MANIFEST_LOCATION=$(MANIFESTS_DIR) -t $(LOCAL_OPERATOR_REGISTRY_IMAGE) -f images/operator-registry/Dockerfile.registry .
+	$(IMAGE_BUILDER) push $(LOCAL_OPERATOR_REGISTRY_IMAGE)
+
+create-cro-cr:
+	$(KUBECTL) apply -f ./artifacts/example/clusterresourceoverride-cr.yaml
+
+delete-cro-cr: delete-api-resources
+delete-cro-cr:
+	$(KUBECTL) delete -f ./artifacts/example/clusterresourceoverride-cr.yaml --ignore-not-found
+
+create-test-pod:
+	$(KUBECTL) apply -f ./artifacts/example/test-namespace.yaml
+	$(KUBECTL) apply -f ./artifacts/example/test-pod.yaml
+
+delete-test-pod:
+	$(KUBECTL) delete -f ./artifacts/example/test-pod.yaml --ignore-not-found
+	$(KUBECTL) delete -f ./artifacts/example/test-namespace.yaml --ignore-not-found
+
+delete-api-resources:
+	$(KUBECTL) delete apiservice v1.admission.autoscaling.openshift.io --ignore-not-found

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ this adjusts the container `limit` and `request` to achieve the desired level of
 `ClusterResourceOverride` Admission Webhook Server is located at [cluster-resource-override-admission](https://github.com/openshift/cluster-resource-override-admission).
 
 ## Prerequisites
-- [git][git_tool]
-- [go][go_tool] version v1.12+.
-- [docker][docker_tool] version 17.03+.
-  - Alternatively [podman][podman_tool] `v1.2.0+` or [buildah][buildah_tool] `v1.7+`
-- [kubectl][kubectl_tool] version v1.11.3+.
+- [git](https://git-scm.com/)
+- [go](https://go.dev/) version `v1.22+`
+- [podman](https://podman.io/docs/installation) version `17.03+`
+  - Alternatively [docker](https://docs.docker.com/engine/install/) `v1.2.0+` or [buildah](https://github.com/containers/buildah/blob/main/install.md) `v1.7+`
+- [kubectl](https://kubernetes.io/docs/reference/kubectl/) version `v1.11.3+`
 - Access to a OpenShift v4.x cluster.
 
 ## Getting Started
@@ -63,6 +63,8 @@ spec:
 This repo ships with an example CR, you can directly apply the YAML resource as well. 
 ```bash
 kubectl apply -f artifacts/example/clusterresourceoverride-cr.yaml
+# or 
+# make create-cro-cr
 ```
 
 The operator watches for the custom resource(s) of `ClusterResourceOverride` type and will ensure that the 
@@ -78,12 +80,11 @@ metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
       {"apiVersion":"operator.autoscaling.openshift.io/v1","kind":"ClusterResourceOverride","metadata":{"annotations":{},"name":"cluster"},"spec":{"podResourceOverride":{"spec":{"cpuRequestToLimitPercent":25,"limitCPUToMemoryPercent":200,"memoryRequestToLimitPercent":50}}}}
-  creationTimestamp: "2019-12-18T22:35:02Z"
+  creationTimestamp: "2024-07-24T17:49:53Z"
   generation: 1
   name: cluster
-  resourceVersion: "127622"
-  selfLink: /apis/operator.autoscaling.openshift.io/v1/clusterresourceoverrides/cluster
-  uid: 978fc959-1717-4bd1-97d0-ae00ee111e8d
+  resourceVersion: "61017"
+  uid: f75c6946-a556-429f-a1f6-99fe31368cb8
 spec:
   podResourceOverride:
     spec:
@@ -91,53 +92,51 @@ spec:
       limitCPUToMemoryPercent: 200
       memoryRequestToLimitPercent: 50
 status:
-  certsRotateAt: "2020-12-15T22:52:46Z"
+  certsRotateAt: null
   conditions:
-  - lastTransitionTime: "2019-12-18T23:27:03Z"
+  - lastTransitionTime: "2024-07-24T17:50:03Z"
     status: "True"
     type: Available
-  - lastTransitionTime: "2019-12-18T23:27:03Z"
+  - lastTransitionTime: "2024-07-24T17:50:02Z"
     status: "False"
     type: InstallReadinessFailure
   hash:
     configuration: 577fe3d2b05619ac326571a3504857e3e7e70a275c941e3397aa9db5c1a1d3a4
-    servingCert: bae6f72e906e9b054d0f4eb4b1540755f284373ad2febdec8454521ebfac5765
-  image: docker.io/tohinkashem/clusterresourceoverride@sha256:f99ed0d7ecf197596bb34eed342ddc8a9169f68b68a457ee5a15070bc68e848a
+  image: quay.io/macao/clusterresourceoverride:dev
   resources:
+    apiServiceRef:
+      apiVersion: apiregistration.k8s.io/v1
+      kind: APIService
+      name: v1.admission.autoscaling.openshift.io
+      resourceVersion: "60981"
+      uid: 79385b4e-43bb-4b14-b145-d50399db4ad8
     configurationRef:
       apiVersion: v1
       kind: ConfigMap
       name: clusterresourceoverride-configuration
-      namespace: cro
-      resourceVersion: "78476"
-      uid: e8a7f90e-90b1-4f2b-9b03-0064ffd33d4b
+      namespace: clusterresourceoverride-operator
+      resourceVersion: "60858"
+      uid: a50a2095-bab9-4834-8be3-633028c35f9e
     deploymentRef:
       apiVersion: apps/v1
-      kind: DaemonSet
+      kind: Deployment
       name: clusterresourceoverride
-      namespace: cro
-      resourceVersion: "78676"
-      uid: 947ebfc5-c244-4621-acc3-c3117a10a97b
+      namespace: clusterresourceoverride-operator
+      resourceVersion: "61013"
+      uid: 4f21e033-e806-48e0-b053-0bbb9d6f688d
     mutatingWebhookConfigurationRef:
       apiVersion: admissionregistration.k8s.io/v1
       kind: MutatingWebhookConfiguration
       name: clusterresourceoverrides.admission.autoscaling.openshift.io
-      resourceVersion: "127621"
-      uid: 98b3b8ae-d5ce-462b-8ab5-a729ea8f38f3
-    serviceCAConfigMapRef:
+      resourceVersion: "61016"
+      uid: 4fd5e040-9445-48de-9ea6-0d7028e5ab5c
+    serviceRef:
       apiVersion: v1
-      kind: ConfigMap
-      name: clusterresourceoverride-service-serving
-      namespace: cro
-      resourceVersion: "78479"
-      uid: faf27927-0fb0-453b-8656-1b05ea9a3d74
-    serviceCertSecretRef:
-      apiVersion: v1
-      kind: Secret
-      name: server-serving-cert-clusterresourceoverride
-      namespace: cro
-      resourceVersion: "78478"
-      uid: cc6efc0e-0fce-4148-a943-6045dadaa72c
+      kind: Service
+      name: clusterresourceoverride
+      namespace: clusterresourceoverride-operator
+      resourceVersion: "60876"
+      uid: 1e343ec2-8c71-4cbc-a236-8c9c3a791db2
   version: 1.0.0
 ```
 
@@ -156,7 +155,9 @@ metadata:
 * Create a `Pod` in the above namespace. The `requests` and `limits` of the `Pod's` `resources` are overridden according to the configuration of the webhook server.
 ```bash
 kubectl apply -f artifacts/example/test-namespace.yaml
-kubectl apply -f artifacts/example/test-pod.yaml    
+kubectl apply -f artifacts/example/test-pod.yaml
+# or
+# make create-test-pod
 ```
 
 The original request of the `Pod` has the following `resources` section. 
@@ -199,13 +200,17 @@ You can also deploy the operator on an OpenShift cluster:
 make build
 
 # build and push operator image
-make dev-image DEV_IMAGE_REGISTRY=docker.io/{your org}/clusterresourceoverride-operator IMAGE_TAG=dev
-make dev-push DEV_IMAGE_REGISTRY=docker.io/{your org}/clusterresourceoverride-operator IMAGE_TAG=dev
+make local-image LOCAL_OPERATOR_IMAGE="{operator image}"
+make local-push LOCAL_OPERATOR_IMAGE="{operator image}"
 
 # deploy on local cluster
-# CLUSTERRESOURCEOVERRIDE_OPERAND_IMAGE: operator image
-# CLUSTERRESOURCEOVERRIDE_OPERATOR_IMAGE: operand image
-make deploy-local CLUSTERRESOURCEOVERRIDE_OPERAND_IMAGE="{operand image}" CLUSTERRESOURCEOVERRIDE_OPERATOR_IMAGE="{operator image}
+# LOCAL_OPERAND_IMAGE: operand image
+# LOCAL_OPERATOR_IMAGE: operator image
+make deploy-local LOCAL_OPERAND_IMAGE="{operand image}" LOCAL_OPERATOR_IMAGE="{operator image}"
+```
+Delete the operator and its resources.
+```bash
+make undeploy-local
 ```
 
 ## Deploy via OLM
@@ -239,4 +244,14 @@ kubectl apply -f artifacts/olm/subscription.yaml
 
 # install the ClusterResourceOverride admission webhook server by creating a custom resource
 kubectl apply -f artifacts/example/clusterresourceoverride-cr.yaml 
+```
+## E2E Tests
+
+To run local E2E tests, you need to have a running OpenShift cluster and the following environment variables set:
+* `KUBECONFIG`: path to the kubeconfig file.
+* `LOCAL_OPERATOR_IMAGE`: operator image.
+* `LOCAL_OPERAND_IMAGE`: operand image.
+
+```bash
+make e2e-local KUBECONFIG={path to kubeconfig} LOCAL_OPERATOR_IMAGE={operator image} LOCAL_OPERAND_IMAGE={operand image}
 ```

--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17 AS builder
 
 WORKDIR /go/src/github.com/openshift/cluster-resource-override-admission-operator
 

--- a/images/dev/Dockerfile.dev
+++ b/images/dev/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM registry.access.redhat.com/ubi9-minimal:9.4
 
 ADD bin/cluster-resource-override-admission-operator /usr/bin
 

--- a/images/operator-registry/Dockerfile.registry
+++ b/images/operator-registry/Dockerfile.registry
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/upstream-registry-builder:v1.13.9 as builder
+FROM quay.io/operator-framework/upstream-registry-builder:v1.30.1 as builder
 
 ARG MANIFEST_LOCATION
 

--- a/images/operator-registry/Dockerfile.registry.ci
+++ b/images/operator-registry/Dockerfile.registry.ci
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/upstream-registry-builder:v1.13.9 as registry-builder
+FROM quay.io/operator-framework/upstream-registry-builder:v1.30.1 as registry-builder
 
 # Since we will use an init container to mutate the CSV file, there is no point in
 # generating the sqlite db here.


### PR DESCRIPTION
* Did not update `Dockerfile.rhel7` referenced in [productization config](https://github.com/openshift-eng/ocp-build-data/blob/39d776b80aa929c42b98e8c50c25162b97b14e06/images/clusterresourceoverride-operator.yml#L3) because ART does not support it yet.
* Updated Makefile
  *  to support other builders/container engines like buildah and podman
  * to add undeploy rule
  * to add rules for applying CR and test-pod 
  * general bug fixes and updates
* Updated images/ci/Dockerfile for consistency on the ci side.
* Updated images/dev/Dockerfile.dev from deprecated centos to ubi9-minimal image
* Updated README.md for better documentation of local development.