### PR TITLE
OCPBUGS-15462: re-inject service account secrets in dynamic ensure client to avoid "secret spam" from openshift-controller-manager

### DIFF
--- a/pkg/dynamic/ensurer.go
+++ b/pkg/dynamic/ensurer.go
@@ -64,9 +64,26 @@ func (c *client) Ensure(resource string, object runtime.Object) (current *unstru
 	modified.SetResourceVersion(original.GetResourceVersion())
 	modified.SetUID(original.GetUID())
 
+	// jkyros: I hate to lodge a special case in this generic ensure function, but OpenShift has special
+	// secret behavior that auto-populates tokens for service accounts, and if we strip them out, the openshift-controller-manager
+	// will keep recreating a ton of secrets in response, see https://issues.redhat.com/browse/OCPBUGS-15462
+	if kind == "ServiceAccount" {
+		// If we have secrets in the original service account, stuff them into the modified so they don't get patched out
+		originalSecrets, secretsFound, err := unstructuredv1.NestedSlice(original.Object, "secrets")
+		if secretsFound && err == nil {
+			unstructuredv1.SetNestedSlice(modified.Object, originalSecrets, "secrets")
+		}
+		// If we have image pull secrets in the original service account, stuff them into the modified so they don't get patched out
+		originalImagePullSecrets, imagePullSeecretsFound, err := unstructuredv1.NestedSlice(original.Object, "imagePullSecrets")
+		if imagePullSeecretsFound && err == nil {
+			unstructuredv1.SetNestedSlice(modified.Object, originalImagePullSecrets, "imagePullSecrets")
+		}
+	}
+
 	bytes, patchErr := PatchWithUnstructured(original, modified, object)
 	if patchErr != nil {
 		err = fmt.Errorf("failed to generate patch %s - %s", kind, patchErr.Error())
+		// TODO(jkyros): If this fails we patch anyway, but it's been like this for so long, I hate to change it
 	}
 
 	current, err = client.Patch(context.TODO(), modified.GetName(), types.StrategicMergePatchType, bytes, metav1.PatchOptions{})


### PR DESCRIPTION
- If the CRO operand would fail to start for some reason
- CRO operator would keep ensuring its environment so it eventually could hopefully start
- Every time the CRO operator "ensured" the service account, the patch it applied stripped the secrets
- This made openshift-controller-manager make new ones every time 
- This resulted in clusters filling up with secrets :disappointed: 

So what I did here was just add a special case to the dynamic ensure client to avoid the unpleasant behavior. We probably need to do a "tech debt" pass on this at some point, but this fix is simple and very cherry-pickable. 

Fixes: [OCPBUGS-15462](https://issues.redhat.com/browse/OCPBUGS-15462)