### PR TITLE
OCPBUGS-44649: Allow clusterresourceoverride-configuration configMap to reconcile on ForceSelinuxRelabel field

### DIFF
--- a/pkg/apis/autoscaling/v1/override.go
+++ b/pkg/apis/autoscaling/v1/override.go
@@ -12,8 +12,8 @@ import (
 )
 
 func (in *PodResourceOverrideSpec) String() string {
-	return fmt.Sprintf("MemoryRequestToLimitPercent=%d, CPURequestToLimitPercent=%d LimitCPUToMemoryPercent=%d",
-		in.MemoryRequestToLimitPercent, in.CPURequestToLimitPercent, in.LimitCPUToMemoryPercent)
+	return fmt.Sprintf("MemoryRequestToLimitPercent=%d, CPURequestToLimitPercent=%d, LimitCPUToMemoryPercent=%d, ForceSelinuxRelabel=%t",
+		in.MemoryRequestToLimitPercent, in.CPURequestToLimitPercent, in.LimitCPUToMemoryPercent, in.ForceSelinuxRelabel)
 }
 
 func (in *PodResourceOverrideSpec) Validate() error {

--- a/pkg/clusterresourceoverride/internal/handlers/configuration.go
+++ b/pkg/clusterresourceoverride/internal/handlers/configuration.go
@@ -60,6 +60,8 @@ func (c *configurationHandler) Handle(context *ReconcileRequestContext, original
 	}
 
 	equal := false
+	// we are hashing the entire override (podResourceOverride+deploymentOverrides) for object tracking/reconcile purposes
+	// but we only persist the podResourceOverride in the ConfigMap for the operand to consume
 	hash := original.Spec.Hash()
 	if hash == current.Status.Hash.Configuration {
 		equal = true

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -226,6 +226,36 @@ func Wait(t *testing.T, client versioned.Interface, name string, f ConditionFunc
 	return
 }
 
+func GetConfigMap(t *testing.T, client kubernetes.Interface, namespace, name string) (cm *corev1.ConfigMap) {
+	cm, err := client.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, cm)
+	return
+}
+
+func WaitForConfigMap(t *testing.T, client kubernetes.Interface, namespace, name string, original *corev1.ConfigMap) (cm *corev1.ConfigMap) {
+	ctx := context.TODO()
+	err := wait.PollUntilContextTimeout(ctx, WaitInterval, WaitTimeout, true, func(ctx context.Context) (done bool, err error) {
+		cm, err = client.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return false, nil
+			}
+
+			return false, err
+		}
+		if cm == nil || cm.ResourceVersion == original.ResourceVersion {
+			return
+		}
+
+		done = true
+		return
+	})
+	require.NoErrorf(t, err, "wait.PollUntilContextTimeout returned error - %v", err)
+	require.NotNil(t, cm)
+	return
+}
+
 func GetAvailableConditionFunc(original *autoscalingv1.ClusterResourceOverride, expectNewResourceVersion bool) ConditionFunc {
 	return func(current *autoscalingv1.ClusterResourceOverride) bool {
 		switch {


### PR DESCRIPTION
Basically just adds the field to the configuration hash.

Only thing that's slightly confusing is that we are hashing the entire override object because of https://github.com/openshift/cluster-resource-override-admission-operator/pull/151, and checking if we need a reconcile based on that hash, but we are only persisting the `podResourceOverride` to the configmap for the operand to consume. I added a comment in the code to take note of this.