### PR TITLE
PODAUTO-267: Updating ose-clusterresourceoverride-operator-container image to be consistent with ART for 4.19

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.22-openshift-4.18
+  tag: rhel-9-release-golang-1.23-openshift-4.19

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
 
 WORKDIR /go/src/github.com/openshift/cluster-resource-override-admission-operator
 COPY . .
 RUN make build
 
-FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 
 LABEL io.k8s.display-name="OpenShift ClusterResourceOverride Operator" \
       io.k8s.description="Manages Pod Resource(s)" \


### PR DESCRIPTION
Blocks https://github.com/openshift/cluster-resource-override-admission-operator/pull/173