### PR TITLE
OCPBUGS-48690: [release-4.16] Allow clusterresourceoverride-configuration configMap to reconcile on ForceSelinuxRelabel field

### DIFF
--- a/pkg/apis/autoscaling/v1/override.go
+++ b/pkg/apis/autoscaling/v1/override.go
@@ -23,8 +23,8 @@ func (in *ClusterResourceOverride) IsTimeToRotateCert() bool {
 }
 
 func (in *PodResourceOverrideSpec) String() string {
-	return fmt.Sprintf("MemoryRequestToLimitPercent=%d, CPURequestToLimitPercent=%d LimitCPUToMemoryPercent=%d",
-		in.MemoryRequestToLimitPercent, in.CPURequestToLimitPercent, in.LimitCPUToMemoryPercent)
+	return fmt.Sprintf("MemoryRequestToLimitPercent=%d, CPURequestToLimitPercent=%d, LimitCPUToMemoryPercent=%d, ForceSelinuxRelabel=%t",
+		in.MemoryRequestToLimitPercent, in.CPURequestToLimitPercent, in.LimitCPUToMemoryPercent, in.ForceSelinuxRelabel)
 }
 
 func (in *PodResourceOverrideSpec) Validate() error {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -16,6 +16,11 @@ import (
 	"github.com/openshift/cluster-resource-override-admission-operator/test/helper"
 )
 
+const (
+	operatorNamespace = "clusterresourceoverride-operator"
+	configMapName     = "clusterresourceoverride-configuration"
+)
+
 func TestClusterResourceOverrideAdmissionWithOptIn(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -355,6 +360,7 @@ func TestClusterResourceOverrideAdmissionWithConfigurationChange(t *testing.T) {
 		LimitCPUToMemoryPercent:     100,
 		CPURequestToLimitPercent:    10,
 		MemoryRequestToLimitPercent: 75,
+		ForceSelinuxRelabel:         false,
 	}
 	override := autoscalingv1.PodResourceOverride{
 		Spec: before,
@@ -372,12 +378,13 @@ func TestClusterResourceOverrideAdmissionWithConfigurationChange(t *testing.T) {
 		LimitCPUToMemoryPercent:     50,
 		CPURequestToLimitPercent:    50,
 		MemoryRequestToLimitPercent: 50,
+		ForceSelinuxRelabel:         false,
 	}
 	override = autoscalingv1.PodResourceOverride{
 		Spec: after,
 	}
 
-	t.Logf("final configuration - %s", after.String())
+	t.Logf("second configuration - %s", after.String())
 
 	current, changed = helper.EnsureAdmissionWebhook(t, client.Operator, "cluster", override)
 	current = helper.Wait(t, client.Operator, "cluster", helper.GetAvailableConditionFunc(current, changed))
@@ -411,6 +418,25 @@ func TestClusterResourceOverrideAdmissionWithConfigurationChange(t *testing.T) {
 	defer disposer.Dispose()
 
 	helper.MustMatchMemoryAndCPU(t, resourceWant, &podGot.Spec)
+
+	// test changing ForceSelinuxRelabel changes the configuration hash and reconciles the configMap
+	after.ForceSelinuxRelabel = true
+	override = autoscalingv1.PodResourceOverride{
+		Spec: after,
+	}
+
+	t.Logf("final configuration: forceSelinuxRelabel - %s", after.String())
+
+	originalCm := helper.GetConfigMap(t, client.Kubernetes, operatorNamespace, configMapName)
+
+	current, changed = helper.EnsureAdmissionWebhook(t, client.Operator, "cluster", override)
+	current = helper.Wait(t, client.Operator, "cluster", helper.GetAvailableConditionFunc(current, changed))
+	require.Equal(t, override.Spec.Hash(), current.Status.Hash.Configuration)
+
+	cm := helper.WaitForConfigMap(t, client.Kubernetes, operatorNamespace, configMapName, originalCm)
+	rawData := cm.Data["configuration.yaml"]
+	require.Contains(t, rawData, "forceSelinuxRelabel: true")
+	require.NotContains(t, rawData, "forceSelinuxRelabel: false")
 }
 
 func TestClusterResourceOverrideAdmissionWithCertRotation(t *testing.T) {

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -221,6 +221,36 @@ func Wait(t *testing.T, client versioned.Interface, name string, f ConditionFunc
 	return
 }
 
+func GetConfigMap(t *testing.T, client kubernetes.Interface, namespace, name string) (cm *corev1.ConfigMap) {
+	cm, err := client.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, cm)
+	return
+}
+
+func WaitForConfigMap(t *testing.T, client kubernetes.Interface, namespace, name string, original *corev1.ConfigMap) (cm *corev1.ConfigMap) {
+	ctx := context.TODO()
+	err := wait.PollUntilContextTimeout(ctx, WaitInterval, WaitTimeout, true, func(ctx context.Context) (done bool, err error) {
+		cm, err = client.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return false, nil
+			}
+
+			return false, err
+		}
+		if cm == nil || cm.ResourceVersion == original.ResourceVersion {
+			return
+		}
+
+		done = true
+		return
+	})
+	require.NoErrorf(t, err, "wait.PollUntilContextTimeout returned error - %v", err)
+	require.NotNil(t, cm)
+	return
+}
+
 func GetAvailableConditionFunc(original *autoscalingv1.ClusterResourceOverride, expectNewResourceVersion bool) ConditionFunc {
 	return func(current *autoscalingv1.ClusterResourceOverride) bool {
 		switch {


### PR DESCRIPTION
Cherry-pick of #172 with some fixed merge conflicts.