### PR TITLE
AUTOSCALE-236: Allow building olm bundles and catalogs for local upgrade testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ _output
 
 # Ignore for asdf: https://github.com/asdf-vm/asdf
 .tool-versions
+
+# Ignore generated catalog
+/catalog/

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,0 +1,16 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=clusterresourceoverride-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.38.0
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=unknown
+
+# Copy files to locations specified by labels.
+COPY bundle/manifests /manifests/
+COPY bundle/metadata /metadata/

--- a/catalog.Dockerfile
+++ b/catalog.Dockerfile
@@ -1,0 +1,22 @@
+# The builder image is expected to contain
+# /bin/opm (with serve subcommand)
+FROM quay.io/operator-framework/opm:latest as builder
+
+# Copy FBC root into image at /configs and pre-populate serve cache
+ADD catalog /configs
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+FROM quay.io/operator-framework/opm:latest
+# The base image is expected to contain
+# /bin/opm (with serve subcommand) and /bin/grpc_health_probe
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+
+COPY --from=builder /configs /configs
+COPY --from=builder /tmp/cache /tmp/cache
+
+# Set FBC-specific label for the location of the FBC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs

--- a/hack/build-bundle.sh
+++ b/hack/build-bundle.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Required: OPERATOR_IMG, OPERAND_IMG, BUNDLE_IMG environment variables
+#
+# This script does a number of steps.
+# 1. Builds the binary, builds the operator image, and pushes it to your specified repo.
+# 2. Generates an OLM bundle with the specified operator and operand img.
+# 3. Builds and pushes a bundle image.
+# 
+# e.g.,
+# 
+#   OPERATOR_IMG=quay.io/macao/clusterresourceoverride-operator:VERSION \
+#   OPERAND_IMG=quay.io/macao/clusterresourceoverride:VERSION \
+#   BUNDLE_IMG=quay.io/macao/cro-bundle:VERSION \
+#   ./hack/build-bundle.sh
+
+REQUIRED_ENV_VARS=("OPERATOR_IMG" "OPERAND_IMG" "BUNDLE_IMG")
+check_env_vars() {
+    local REQUIRED_VARS=("$@")
+    for VAR_NAME in "${REQUIRED_VARS[@]}"; do
+        if [ -z "${!VAR_NAME:-}" ]; then
+            echo "Error: $VAR_NAME environment variable is not set." ; exit 1
+        fi
+    done
+}
+
+check_env_vars "${REQUIRED_ENV_VARS[@]}"
+
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+ROOT_DIR=$SCRIPT_DIR/..
+
+# Build and push the operator image
+make build
+podman build -t "$OPERATOR_IMG" -f ./images/dev/Dockerfile.dev .
+podman push "$OPERATOR_IMG"
+
+rm -rf bundle
+
+# Aggregate files by --- separators
+awk 'FNR==1 && NR!=1 {print "---"} {print}' artifacts/deploy/* manifests/stable/* | operator-sdk generate bundle \
+    --package clusterresourceoverride-operator \
+    --default-channel stable \
+    --channels stable
+
+trap "rm -rf bundle" EXIT
+
+CSV_BUNDLE_PATH=$ROOT_DIR/bundle/manifests/clusterresourceoverride-operator.clusterserviceversion.yaml
+
+if ! [ -e "$CSV_BUNDLE_PATH" ]; then
+    echo "File $CSV_BUNDLE_PATH doesn't exist." ; exit 1
+fi
+
+# Update the CSV bundle with correct image references
+sed -e "s|CLUSTERRESOURCEOVERRIDE_OPERATOR_IMAGE|$OPERATOR_IMG|g" \
+    -e "s|CLUSTERRESOURCEOVERRIDE_OPERAND_IMAGE|$OPERAND_IMG|g" \
+    "$CSV_BUNDLE_PATH" -i
+
+# Validate the bundle
+operator-sdk bundle validate ./bundle
+
+# Build and push the bundle image
+podman build -t "$BUNDLE_IMG" -f bundle.Dockerfile .
+podman push "$BUNDLE_IMG"

--- a/hack/build-fbc.sh
+++ b/hack/build-fbc.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Required: CATALOG_REPO, BUNDLE_REPO, PREV_VERSION environment variables
+#
+# This script builds an OLM file-based-catalog and outputs it to
+# catalog/cro-fbc.yaml.
+#
+# # Assumes BUNDLE_REPO refers to an image repository that contains
+# a CRO bundle that points to the current branch version, and assumes
+# there exists a bundle that points to the PREV_VERSION.
+# 
+# Note that there should be no tag attached to the environment vars.
+#
+# This script is intended to be used alongside ./hack/build-bundle.sh 
+# for building catalogs with multiple bundles for testing operator upgrades.
+# If needed in the future, it can be allowed to specify a custom catalog template.
+# 
+# e.g.,
+# 
+#   CATALOG_REPO=quay.io/macao/cro-catalog \
+#   BUNDLE_REPO=quay.io/macao/cro-bundle \
+#   PREV_VERSION=4.16
+#   ./hack/build-fbc.sh
+
+REQUIRED_ENV_VARS=("CATALOG_REPO" "BUNDLE_REPO" "PREV_VERSION")
+check_env_vars() {
+    local REQUIRED_VARS=("$@")
+    for VAR_NAME in "${REQUIRED_VARS[@]}"; do
+        if [ -z "${!VAR_NAME:-}" ]; then
+            echo "Error: $VAR_NAME environment variable is not set." ; exit 1
+        fi
+    done
+}
+
+check_env_vars "${REQUIRED_ENV_VARS[@]}"
+
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+ROOT_DIR=$SCRIPT_DIR/..
+
+# Get version from Makefile
+VERSION=$(awk -F ':=' '/^IMAGE_VERSION/ {print $2}' "$ROOT_DIR/Makefile" | xargs)
+
+TEMPLATE="
+schema: olm.template.basic
+entries:
+  - schema: olm.package
+    name: clusterresourceoverride-operator
+    defaultChannel: stable
+  - schema: olm.channel
+    package: clusterresourceoverride-operator
+    name: stable
+    entries:
+      - name: clusterresourceoverride-operator.v$PREV_VERSION.0
+      - name: clusterresourceoverride-operator.v$VERSION.0
+        replaces: clusterresourceoverride-operator.v$PREV_VERSION.0
+  - schema: olm.bundle
+    image: $BUNDLE_REPO:v$VERSION
+  - schema: olm.bundle
+    image: $BUNDLE_REPO:v$PREV_VERSION
+"
+
+# Generate the fbc
+mkdir -p catalog
+echo "$TEMPLATE" | opm alpha render-template basic -oyaml >| catalog/cro-fbc.yaml
+
+# Build and push the catalog image
+podman build -t "$CATALOG_REPO:v$VERSION" -f "$ROOT_DIR"/catalog.Dockerfile "$ROOT_DIR"
+podman push "$CATALOG_REPO:v$VERSION"

--- a/hack/deploy-catalogsource.sh
+++ b/hack/deploy-catalogsource.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Required: CATALOG_IMG environment variables
+#
+# This script applies a catalog source to your cluster containing
+# the built catalog image.
+#
+# e.g., CATALOG_IMG=quay.io/macao/cro-catalog:v4.19 ./hack/deploy-catalogsource.sh
+
+DISPLAY_NAME="Cluster Resource Override Operator dev catalog"
+PKG_NAME=clusterresourceoverride-operator
+
+# Get namespace of the installed operator if it exists (cleanup)
+NAMESPACE=$(oc get subscriptions --all-namespaces -o json | \
+  jq -r "[.items[] | select(.spec.name == \"$PKG_NAME\") | .metadata.namespace] | first // \"\"")
+if [ -n "$NAMESPACE" ]; then
+  operator-sdk cleanup -n "$NAMESPACE" "$PKG_NAME"
+fi
+
+oc apply -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: cro-fbc
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: $CATALOG_IMG
+  displayName: $DISPLAY_NAME
+  publisher: autoscaling-team
+  updateStrategy:
+    registryPoll:
+      interval: 10m
+EOF
+
+echo
+echo -n "Waiting for package manifest to become available."
+first=1
+while [ $first = 1 ] || sleep 5; do
+  first=0
+  [ "$(oc get packagemanifest -n openshift-marketplace -o json | \
+    jq -r "[ .items[] | select(.metadata.name==\"$PKG_NAME\") | select(.status.catalogSourceDisplayName == \"$DISPLAY_NAME\") ] | length")" -gt 0 ] && break
+  echo -n .
+done
+echo " done"


### PR DESCRIPTION
Adds some scripts and Dockerfiles that help in building local OLM bundles and catalogs.

Here's an example workflow.

If you want to reproduce an upgrade regression bug, you will want to build a bundle containing the version before that bug, and a bundle container some version after it. You first:
1. Checkout the release branch of the version before the bug was introduced.
2. run `./hack/build-bundle.sh` and make sure your environment variables are set to build and push a bundle image (make sure you're logged into podman/docker/whatever and that the image will be public)
3. Checkout the release branch of some version after the bug was introduced.
4. Do part 2 again for this version but with a different tag/pullspec.
5. Run `./hack/build-catalog.sh` with the right env vars, in order to build a catalog that contains the two bundle images and an upgrade path between them.
6. Run `./hack/deploy-catalogsource.sh` with `CATALOG_IMG` pointing to the catalog image you just built and pushed.
7. Wait for it to finish and then install the preceding operator version from the OperatorHub.

Note that this requires the openshift console (but you can probably do it only using command line).
This also requires `opm` and `operator-sdk` binaries.
