### PR TITLE
OCPBUGS-54886: delete old self-signed cert secret if it exists

### DIFF
--- a/artifacts/deploy/200_rbac.yaml
+++ b/artifacts/deploy/200_rbac.yaml
@@ -178,6 +178,13 @@ rules:
     - patch
     - list
     - watch
+  
+  - apiGroups:
+    - ''
+    resources:
+    - secrets
+    verbs:
+    - delete
 
   # to have the power to watch secondary resources
   - apiGroups:

--- a/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
+++ b/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
@@ -119,6 +119,13 @@ spec:
             - patch
             - list
             - watch
+          
+        - apiGroups:
+          - ''
+          resources:
+          - secrets
+          verbs:
+          - delete
 
         # to have the power to watch secondary resources
         - apiGroups:


### PR DESCRIPTION
Fixes: [OCPBUGS-54886](https://issues.redhat.com/browse/OCPBUGS-54886)

Checks if there exists the serving cert secret in the cro namespace. 

If it exists, and doesn't have the service-ca operator annotation, then delete it. It is the old self-signed generated cert that is embedded in a secret that we generated from the operator before 4.17. The service-ca operator will regenerate the secret with the correct annotation and the correct SAN in the cert that is signed by openshift.

If it doesn't exist, just passthrough like normal.

We need to add some rbac to the operator in order to delete the secret.

I tested this using the method in https://github.com/openshift/cluster-resource-override-admission-operator/pull/179