### PR TITLE
AUTOSCALE-236: Generate a bundle for CI to consume

### DIFF
--- a/bundle/manifests/clusterresourceoverride-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterresourceoverride-operator.clusterserviceversion.yaml
@@ -1,0 +1,363 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[]'
+    capabilities: Seamless Upgrades
+    categories: OpenShift Optional
+    certifiedLevel: Primed
+    containerImage: quay.io/openshift/clusterresourceoverride-rhel8-operator:4.19
+    createdAt: "2025-04-24T18:18:17Z"
+    description: An operator to manage the OpenShift ClusterResourceOverride Mutating
+      Admission Webhook Server
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    healthIndex: B
+    olm.skipRange: '>=4.3.0 <4.19.0'
+    operators.operatorframework.io/builder: operator-sdk-v1.38.0
+    operators.operatorframework.io/project_layout: unknown
+    repository: https://github.com/openshift/cluster-resource-override-admission-operator
+    support: Red Hat
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
+  name: clusterresourceoverride-operator.v4.19.0
+  namespace: clusterresourceoverride-operator
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Represents an instance of ClusterResourceOverride Admission Webhook
+      displayName: ClusterResourceOverride
+      kind: ClusterResourceOverride
+      name: clusterresourceoverrides.operator.autoscaling.openshift.io
+      version: v1
+  description: "ClusterResourceOverride\n==============\n\nContainers can specify
+    compute resource requests and limits. Requests are used for scheduling your container
+    and provide a minimum service guarantee. Limits constrain the amount of compute
+    resource that may be consumed on your node.\n\nThe scheduler attempts to optimize
+    the compute resource use across all nodes in your cluster. It places pods onto
+    specific nodes, taking the pods' compute resource requests and nodes' available
+    capacity into consideration.\n\nRequests and limits enable administrators to allow
+    and manage the overcommitment of resources on a node, which may be desirable in
+    development environments where a trade off of guaranteed performance for capacity
+    is acceptable.\n\n### Requests and Limits\n\nFor each compute resource, a container
+    may specify a resource request and limit. Scheduling decisions are made based
+    on the request to ensure that a node has enough capacity available to meet the
+    requested value. If a container specifies limits, but omits requests, the requests
+    are defaulted to the limits. A container is not able to exceed the specified limit
+    on the node.\n\nThe enforcement of limits is dependent upon the compute resource
+    type. If a container makes no request or limit, the container is scheduled to
+    a node with no resource guarantees. In practice, the container is able to consume
+    as much of the specified resource as is available with the lowest local priority.
+    In low resource situations, containers that specify no resource requests are given
+    the lowest quality of service.\n\n### Compute Resources\n\nThe node-enforced behavior
+    for compute resources is specific to the resource type.\n\n#### CPU\n\nA container
+    is guaranteed the amount of CPU it requests and is additionally able to consume
+    excess CPU available on the node, up to any limit specified by the container.
+    If multiple containers are attempting to use excess CPU, CPU time is distributed
+    based on the amount of CPU requested by each container.\n\nFor example, if one
+    container requested 500m of CPU time and another container requested 250m of CPU
+    time, then any extra CPU time available on the node is distributed among the containers
+    in a 2:1 ratio. If a container specified a limit, it will be throttled not to
+    use more CPU than the specified limit.\n\nCPU requests are enforced using the
+    CFS shares support in the Linux kernel. By default, CPU limits are enforced using
+    the CFS quota support in the Linux kernel over a 100ms measuring interval, though
+    this can be disabled.\n\n#### Memory\n\nA container is guaranteed the amount of
+    memory it requests. A container may use more memory than requested, but once it
+    exceeds its requested amount, it could be killed in a low memory situation on
+    the node.\n\nIf a container uses less memory than requested, it will not be killed
+    unless system tasks or daemons need more memory than was accounted for in the
+    node’s resource reservation. If a container specifies a limit on memory, it is
+    immediately killed if it exceeds the limit amount.\n\n### Configuring the Cluster
+    for Overcommitment\n\nScheduling is based on resources requested, while quota
+    and hard limits refer to resource limits, which can be set higher than requested
+    resources. The difference between request and limit determines the level of overcommit;
+    for instance, if a container is given a memory request of 1Gi and a memory limit
+    of 2Gi, it is scheduled based on the 1Gi request being available on the node,
+    but could use up to 2Gi; so it is 200% overcommitted. If OpenShift Container Platform
+    administrators would like to control the level of overcommit and manage container
+    density on nodes, ClusterResourceOverride Admission Webhook can be configured
+    to override the ratio between request and limit set on developer containers. In
+    conjunction with a per-project LimitRange specifying limits and defaults, this
+    adjusts the container limit and request to achieve the desired level of overcommit.\n\nThis
+    requires creating a custom resource of `ClusterResourceOverride` type as in the
+    following example:\n\n    \n    - apiVersion: operator.autoscaling.openshift.io/v1\n
+    \   - kind: ClusterResourceOverride\n    - metadata:\n    -   name: cluster\n
+    \   - spec:\n    -   podResourceOverride:\n    -     spec:\n    -       memoryRequestToLimitPercent:
+    25\n    -       cpuRequestToLimitPercent: 25\n    -       limitCPUToMemoryPercent:
+    200\n    \n **memoryRequestToLimitPercent**: (optional, 1-100) If a container
+    memory limit has been specified or defaulted, the memory request is overridden
+    to this percentage of the limit.\n\n **cpuRequestToLimitPercent**: (optional,
+    1-100) If a container CPU limit has been specified or defaulted, the CPU request
+    is overridden to this percentage of the limit.\n\n **limitCPUToMemoryPercent**:
+    (optional, positive integer) If a container memory limit has been specified or
+    defaulted, the CPU limit is overridden to a percentage of the memory limit, with
+    a 100 percentage scaling 1Gi of RAM to equal 1 CPU core. This is processed prior
+    to overriding CPU request (if configured).\n\n Note that these overrides have
+    no effect if no limits have been set on containers. [Create a LimitRange object]
+    (https://docs.openshift.com/container-platform/3.3/admin_guide/limits.html#admin-guide-limits)
+    with default limits (per individual project, or in the [project template](https://docs.openshift.com/container-platform/3.3/admin_guide/managing_projects.html#modifying-the-template-for-new-projects))
+    in order to ensure that the overrides apply.\n\nWhen configured, overrides can
+    be enabled per-project by applying the following label.\n    ```\n    clusterresourceoverrides.admission.autoscaling.openshift.io/enabled:
+    \"true\"\n    ```\n\n"
+  displayName: ClusterResourceOverride Operator
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          verbs:
+          - create
+          - update
+          - patch
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          verbs:
+          - create
+          - update
+          - patch
+          - get
+        - apiGroups:
+          - operator.autoscaling.openshift.io
+          resources:
+          - clusterresourceoverrides
+          - clusterresourceoverrides/status
+          - clusterresourceoverrides/finalizers
+          verbs:
+          - update
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - flowcontrol.apiserver.k8s.io
+          resources:
+          - prioritylevelconfigurations
+          - flowschemas
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          verbs:
+          - create
+          - update
+          - patch
+          - delete
+          - list
+          - watch
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          verbs:
+          - create
+          - update
+          - patch
+          - get
+          - list
+          - watch
+          - delete
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          - mutatingwebhookconfigurations
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          - limitranges
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        - apiGroups:
+          - admission.autoscaling.openshift.io
+          resources:
+          - clusterresourceoverrides
+          verbs:
+          - create
+          - get
+        serviceAccountName: clusterresourceoverride-operator
+      deployments:
+      - label:
+          clusterresourceoverride.operator: "true"
+        name: clusterresourceoverride-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              clusterresourceoverride.operator: "true"
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                clusterresourceoverride.operator: "true"
+              name: clusterresourceoverride
+            spec:
+              containers:
+              - args:
+                - start
+                - --namespace=$(OPERAND_NAMESPACE)
+                - --v=2
+                command:
+                - /usr/bin/cluster-resource-override-admission-operator
+                env:
+                - name: OPERATOR_POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: OPERAND_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: OPERAND_IMAGE
+                  value: quay.io/placeholder/operand:1.0
+                - name: OPERAND_VERSION
+                  value: 1.0.0
+                image: quay.io/placeholder/operator:1.0
+                imagePullPolicy: Always
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8080
+                  initialDelaySeconds: 5
+                name: clusterresourceoverride-operator
+                ports:
+                - containerPort: 8080
+                readinessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8080
+                resources: {}
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+              serviceAccountName: clusterresourceoverride-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - create
+          - update
+          - patch
+          - get
+        - apiGroups:
+          - flowcontrol.apiserver.k8s.io
+          resources:
+          - prioritylevelconfigurations
+          - flowschemas
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - secrets
+          - services
+          - serviceaccounts
+          - pods
+          verbs:
+          - get
+          - create
+          - update
+          - patch
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - delete
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - deployments
+          verbs:
+          - create
+          - get
+          - update
+          - patch
+          - list
+          - watch
+          - delete
+        serviceAccountName: clusterresourceoverride-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - deschedule
+  - scale
+  - binpack
+  - efficiency
+  labels:
+    olm-owner-enterprise-app: clusterresourceoverride-operator
+    olm-status-descriptors: clusterresourceoverride-operator.v4.19.0
+  maintainers:
+  - email: support@redhat.com
+    name: Red Hat
+  provider:
+    name: Red Hat
+  version: 4.19.0

--- a/bundle/manifests/operator.autoscaling.openshift.io_clusterresourceoverrides.yaml
+++ b/bundle/manifests/operator.autoscaling.openshift.io_clusterresourceoverrides.yaml
@@ -1,0 +1,111 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: clusterresourceoverrides.operator.autoscaling.openshift.io
+spec:
+  conversion:
+    strategy: None
+  group: operator.autoscaling.openshift.io
+  names:
+    kind: ClusterResourceOverride
+    listKind: ClusterResourceOverrideList
+    plural: clusterresourceoverrides
+    shortNames:
+    - cro
+    singular: clusterresourceoverride
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Allows cluster administrator to control the level of overcommit
+          and manage container density on nodes.
+        properties:
+          spec:
+            description: Spec for a ClusterResourceOverride.
+            properties:
+              deploymentOverrides:
+                description: Deployment overrides for ClusterResourceOverrides.
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: (optional) NodeSelector to apply to ClusterResourceOverrides
+                      deployments.
+                    type: object
+                  replicas:
+                    description: (optional) Number of replicas for ClusterResourceOverrides
+                      deployments. This number must not exceed the number of nodes
+                      that can accommodate the replicas, considering tolerations,
+                      and node selectors.
+                    minimum: 0
+                    type: integer
+                  tolerations:
+                    description: (optional) Tolerations to apply to ClusterResourceOverrides
+                      deployments.
+                    items:
+                      properties:
+                        effect:
+                          type: string
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        tolerationSeconds:
+                          type: integer
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              podResourceOverride:
+                description: Configuration for Pod resource overrides.
+                properties:
+                  spec:
+                    description: Spec for Pod resource overrides.
+                    properties:
+                      cpuRequestToLimitPercent:
+                        description: (optional, 1-100) If a container CPU limit has
+                          been specified or defaulted, the CPU request is overridden
+                          to this percentage of the limit.
+                        maximum: 100
+                        minimum: 1
+                        type: integer
+                      forceSelinuxRelabel:
+                        description: (optional, false) Enable the Selinux relabelling
+                          fix.
+                        type: boolean
+                      limitCPUToMemoryPercent:
+                        description: (optional, positive integer) If a container memory
+                          limit has been specified or defaulted, the CPU limit is
+                          overridden to a percentage of the memory limit, with a 100
+                          percentage scaling 1Gi of RAM to equal 1 CPU core. This
+                          is processed prior to overriding CPU request (if configured).
+                        minimum: 0
+                        type: integer
+                      memoryRequestToLimitPercent:
+                        description: (optional, 1-100) If a container memory limit
+                          has been specified or defaulted, the memory request is overridden
+                          to this percentage of the limit.
+                        maximum: 100
+                        minimum: 1
+                        type: integer
+                    type: object
+                type: object
+            type: object
+          status:
+            description: The status of the ClusterResourceOverride
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -1,0 +1,11 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: clusterresourceoverride-operator
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.38.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: unknown

--- a/hack/build-fbc.sh
+++ b/hack/build-fbc.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 # 
 # Note that there should be no tag attached to the environment vars.
 #
-# This script is intended to be used alongside ./hack/build-bundle.sh 
+# This script is intended to be used alongside ./hack/generate-bundle.sh 
 # for building catalogs with multiple bundles for testing operator upgrades.
 # If needed in the future, it can be allowed to specify a custom catalog template.
 # 

--- a/hack/generate-bundle.sh
+++ b/hack/generate-bundle.sh
@@ -2,39 +2,38 @@
 
 set -euo pipefail
 
+# TODO(maxcao13): This is hack script to generate an OLM bundle
+# We should remove it if we migrate to operator-sdk project and use `make bundle` instead
+
 # Required: OPERATOR_IMG, OPERAND_IMG, BUNDLE_IMG environment variables
+# Optional: SKIP_BUILD
 #
 # This script does a number of steps.
-# 1. Builds the binary, builds the operator image, and pushes it to your specified repo.
+# 1. Builds the binary, builds the operator image (if enabled), and pushes it to your specified repo.
 # 2. Generates an OLM bundle with the specified operator and operand img.
-# 3. Builds and pushes a bundle image.
+# 3. Builds and pushes a bundle image, if SKIP_BUILD is not true.
 # 
 # e.g.,
 # 
 #   OPERATOR_IMG=quay.io/macao/clusterresourceoverride-operator:VERSION \
 #   OPERAND_IMG=quay.io/macao/clusterresourceoverride:VERSION \
 #   BUNDLE_IMG=quay.io/macao/cro-bundle:VERSION \
-#   ./hack/build-bundle.sh
+#   ./hack/generate-bundle.sh
 
-REQUIRED_ENV_VARS=("OPERATOR_IMG" "OPERAND_IMG" "BUNDLE_IMG")
-check_env_vars() {
-    local REQUIRED_VARS=("$@")
-    for VAR_NAME in "${REQUIRED_VARS[@]}"; do
-        if [ -z "${!VAR_NAME:-}" ]; then
-            echo "Error: $VAR_NAME environment variable is not set." ; exit 1
-        fi
-    done
-}
-
-check_env_vars "${REQUIRED_ENV_VARS[@]}"
+operator_img=${OPERATOR_IMG:-"quay.io/placeholder/operator:1.0"}
+operand_img=${OPERAND_IMG:-"quay.io/placeholder/operand:1.0"}
+bundle_img=${BUNDLE_IMG:-"quay.io/placeholder/bundle:1.0"}
+skip_build=${SKIP_BUILD:-"false"}
 
 SCRIPT_DIR=$(dirname "$(realpath "$0")")
 ROOT_DIR=$SCRIPT_DIR/..
 
 # Build and push the operator image
-make build
-podman build -t "$OPERATOR_IMG" -f ./images/dev/Dockerfile.dev .
-podman push "$OPERATOR_IMG"
+if [ "$skip_build" == "false" ]; then
+    make build
+    podman build -t "$operator_img" -f ./images/dev/Dockerfile.dev .
+    podman push "$operator_img"
+fi
 
 rm -rf bundle
 
@@ -44,8 +43,6 @@ awk 'FNR==1 && NR!=1 {print "---"} {print}' artifacts/deploy/* manifests/stable/
     --default-channel stable \
     --channels stable
 
-trap "rm -rf bundle" EXIT
-
 CSV_BUNDLE_PATH=$ROOT_DIR/bundle/manifests/clusterresourceoverride-operator.clusterserviceversion.yaml
 
 if ! [ -e "$CSV_BUNDLE_PATH" ]; then
@@ -53,13 +50,15 @@ if ! [ -e "$CSV_BUNDLE_PATH" ]; then
 fi
 
 # Update the CSV bundle with correct image references
-sed -e "s|CLUSTERRESOURCEOVERRIDE_OPERATOR_IMAGE|$OPERATOR_IMG|g" \
-    -e "s|CLUSTERRESOURCEOVERRIDE_OPERAND_IMAGE|$OPERAND_IMG|g" \
+sed -e "s|CLUSTERRESOURCEOVERRIDE_OPERATOR_IMAGE|$operator_img|g" \
+    -e "s|CLUSTERRESOURCEOVERRIDE_OPERAND_IMAGE|$operand_img|g" \
     "$CSV_BUNDLE_PATH" -i
 
 # Validate the bundle
 operator-sdk bundle validate ./bundle
 
 # Build and push the bundle image
-podman build -t "$BUNDLE_IMG" -f bundle.Dockerfile .
-podman push "$BUNDLE_IMG"
+if [ "$skip_build" == "false" ]; then
+    podman build -t "$bundle_img" -f bundle.Dockerfile .
+    podman push "$bundle_img"
+fi


### PR DESCRIPTION
Renames `build-bundle.sh -> generate-bundle.sh` and commits the generated bundle.

We need this because it makes it easier for CI to run operator-sdk upgrade tests by allowing it to consume an existing bundle and promote the bundle image through CI. Reference from this page: https://docs.ci.openshift.org/docs/how-tos/testing-operator-sdk-operators/#operator-upgrade-testing

Bundle was created by doing:

```
$ SKIP_BUILD=true ./hack/generate-bundle.sh
Generating bundle
Generating bundle manifests
...
````