### PR TITLE
OCPBUGS-61410: Updates for 4.21 to satisfy ART builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ CONTAINER_ENGINE ?= podman
 # can support podman, docker, and buildah
 IMAGE_BUILDER ?= $(CONTAINER_ENGINE)
 # this is the version of the operator that should change with each release
-IMAGE_VERSION := 4.20
+IMAGE_VERSION := 4.21
 # this is the image tag of your custom dev image
 IMAGE_TAG := dev
 

--- a/bundle/manifests/clusterresourceoverride-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterresourceoverride-operator.clusterserviceversion.yaml
@@ -6,8 +6,8 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional
     certifiedLevel: Primed
-    containerImage: quay.io/openshift/clusterresourceoverride-rhel8-operator:4.20
-    createdAt: "2025-06-17T19:45:02Z"
+    containerImage: quay.io/openshift/clusterresourceoverride-rhel8-operator:4.21
+    createdAt: "2025-09-24T20:11:28Z"
     description: An operator to manage the OpenShift ClusterResourceOverride Mutating
       Admission Webhook Server
     features.operators.openshift.io/disconnected: "true"
@@ -18,7 +18,7 @@ metadata:
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
     healthIndex: B
-    olm.skipRange: '>=4.3.0 <4.20.0'
+    olm.skipRange: '>=4.3.0 <4.21.0'
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/openshift/cluster-resource-override-admission-operator
@@ -27,7 +27,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: clusterresourceoverride-operator.v4.20.0
+  name: clusterresourceoverride-operator.v4.21.0
   namespace: clusterresourceoverride-operator
 spec:
   apiservicedefinitions: {}
@@ -354,10 +354,10 @@ spec:
   - efficiency
   labels:
     olm-owner-enterprise-app: clusterresourceoverride-operator
-    olm-status-descriptors: clusterresourceoverride-operator.v4.20.0
+    olm-status-descriptors: clusterresourceoverride-operator.v4.21.0
   maintainers:
   - email: support@redhat.com
     name: Red Hat
   provider:
     name: Red Hat
-  version: 4.20.0
+  version: 4.21.0

--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -10,5 +10,5 @@ updates:
         replace: 'olm.skipRange: ">=4.3.0 <{FULL_VER}"'
   - file: "clusterresourceoverride-operator.package.yaml"
     update_list:
-      - search: "currentCSV: clusterresourceoverride-operator.v4.20.0"
+      - search: "currentCSV: clusterresourceoverride-operator.v4.21.0"
         replace: "currentCSV: clusterresourceoverride-operator.{FULL_VER}"

--- a/manifests/clusterresourceoverride-operator.package.yaml
+++ b/manifests/clusterresourceoverride-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: clusterresourceoverride
 channels:
   - name: stable
-    currentCSV: clusterresourceoverride-operator.v4.20.0
+    currentCSV: clusterresourceoverride-operator.v4.21.0

--- a/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
+++ b/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
@@ -6,8 +6,8 @@ metadata:
     capabilities: Seamless Upgrades
     categories: OpenShift Optional
     certifiedLevel: Primed
-    olm.skipRange: ">=4.3.0 <4.20.0"
-    containerImage: quay.io/openshift/clusterresourceoverride-rhel8-operator:4.20
+    olm.skipRange: ">=4.3.0 <4.21.0"
+    containerImage: quay.io/openshift/clusterresourceoverride-rhel8-operator:4.21
     createdAt: 2019/11/15
     description: An operator to manage the OpenShift ClusterResourceOverride Mutating Admission Webhook Server
     healthIndex: B
@@ -24,7 +24,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/arch.ppc64le: supported
-  name: clusterresourceoverride-operator.v4.20.0
+  name: clusterresourceoverride-operator.v4.21.0
   namespace: clusterresourceoverride-operator
 spec:
   customresourcedefinitions:
@@ -290,7 +290,7 @@ spec:
                 serviceAccountName: clusterresourceoverride-operator
                 containers:
                   - name: clusterresourceoverride-operator
-                    image: quay.io/openshift/clusterresourceoverride-rhel8-operator:4.20
+                    image: quay.io/openshift/clusterresourceoverride-rhel8-operator:4.21
                     imagePullPolicy: Always
                     command:
                       - /usr/bin/cluster-resource-override-admission-operator
@@ -308,7 +308,7 @@ spec:
                           fieldRef:
                             fieldPath: metadata.namespace
                       - name: OPERAND_IMAGE
-                        value: quay.io/openshift/clusterresourceoverride-rhel8:4.20
+                        value: quay.io/openshift/clusterresourceoverride-rhel8:4.21
                       - name: OPERAND_VERSION
                         value: 1.0.0
                     ports:
@@ -347,10 +347,10 @@ spec:
     - efficiency
   labels:
     olm-owner-enterprise-app: clusterresourceoverride-operator
-    olm-status-descriptors: clusterresourceoverride-operator.v4.20.0
+    olm-status-descriptors: clusterresourceoverride-operator.v4.21.0
   maintainers:
     - email: support@redhat.com
       name: Red Hat
   provider:
     name: Red Hat
-  version: 4.20.0
+  version: 4.21.0

--- a/manifests/stable/image-references
+++ b/manifests/stable/image-references
@@ -6,8 +6,8 @@ spec:
   - name: clusterresourceoverride-rhel8-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/clusterresourceoverride-rhel8-operator:4.20
+      name: quay.io/openshift/clusterresourceoverride-rhel8-operator:4.21
   - name: clusterresourceoverride-rhel8
     from:
       kind: DockerImage
-      name: quay.io/openshift/clusterresourceoverride-rhel8:4.20
+      name: quay.io/openshift/clusterresourceoverride-rhel8:4.21


### PR DESCRIPTION
```bash
$ sed -i 's/4.20/4.21/g' Makefile  manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml manifests/stable/image-references manifests/art.yaml manifests/clusterresourceoverride-operator.package.yaml
$ SKIP_BUILD=true ./hack/generate-bundle.sh
```

Note there is no:
-   dockerfile image bumping
-   rebasing
-   deps bumping
as part of this PR. It should be transparent in terms of functionality.

I didn't include the extra commits in https://github.com/openshift/vertical-pod-autoscaler-operator/pull/209 to reduce the amount of bumping we do because those files in this repo are actually needed to be versioned for a local and CI deploy (at least without changing how it works, and that's a unneeded hassle).