### PR TITLE
AUTOSCALE-705: Added cpuRequestToRequestPercent field to CRD

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ spec:
       memoryRequestToLimitPercent: 50
       cpuRequestToLimitPercent: 25
       limitCPUToMemoryPercent: 200
+      cpuRequestToRequestPercent: 25
 ```
 
 This repo ships with an example CR, you can directly apply the YAML resource as well. 

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=clusterresourceoverride-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.42.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.42.2
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=unknown
 

--- a/bundle/manifests/clusterresourceoverride-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterresourceoverride-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: OpenShift Optional
     certifiedLevel: Primed
     containerImage: quay.io/openshift/clusterresourceoverride-rhel8-operator:4.22
-    createdAt: "2026-02-04T18:14:43Z"
+    createdAt: "2026-06-16T22:26:09Z"
     description: An operator to manage the OpenShift ClusterResourceOverride Mutating
       Admission Webhook Server
     features.operators.openshift.io/disconnected: "true"
@@ -19,7 +19,7 @@ metadata:
     features.operators.openshift.io/token-auth-gcp: "false"
     healthIndex: B
     olm.skipRange: '>=4.3.0 <4.22.0'
-    operators.operatorframework.io/builder: operator-sdk-v1.42.0
+    operators.operatorframework.io/builder: operator-sdk-v1.42.2
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/openshift/cluster-resource-override-admission-operator
     support: Red Hat

--- a/bundle/manifests/operator.autoscaling.openshift.io_clusterresourceoverrides.yaml
+++ b/bundle/manifests/operator.autoscaling.openshift.io_clusterresourceoverrides.yaml
@@ -72,6 +72,15 @@ spec:
                         maximum: 100
                         minimum: 1
                         type: integer
+                      cpuRequestToRequestPercent:
+                        description: (optional, 1-100) If a container CPU limit has
+                          not been specified or defaulted, the CPU request is overridden
+                          to this percentage of the existing CPU request. This is
+                          processed after all configured overrides, so any CPU limit
+                          set by limitCPUToMemoryPercent will disable cpuRequestToRequestPercent.
+                        maximum: 100
+                        minimum: 1
+                        type: integer
                       forceSelinuxRelabel:
                         description: (optional, false) Enable the Selinux relabelling
                           fix.

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,6 +6,6 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: clusterresourceoverride-operator
   operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.2
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: unknown

--- a/manifests/stable/clusterresourceoverride.crd.yaml
+++ b/manifests/stable/clusterresourceoverride.crd.yaml
@@ -54,6 +54,11 @@ spec:
                         type: integer
                         description: (optional, positive integer) If a container memory limit has been specified or defaulted, the CPU limit is overridden to a percentage of the memory limit, with a 100 percentage scaling 1Gi of RAM to equal 1 CPU core. This is processed prior to overriding CPU request (if configured).
                         minimum: 0
+                      cpuRequestToRequestPercent:
+                        type: integer
+                        description: (optional, 1-100) If a container CPU request has been specified or defaulted, the CPU request is overridden to this percentage of the existing CPU request. This is processed after all configured overrides.
+                        minimum: 1
+                        maximum: 100
               deploymentOverrides:
                 type: object
                 description: Deployment overrides for ClusterResourceOverrides.

--- a/pkg/apis/autoscaling/v1/override.go
+++ b/pkg/apis/autoscaling/v1/override.go
@@ -12,8 +12,8 @@ import (
 )
 
 func (in *PodResourceOverrideSpec) String() string {
-	return fmt.Sprintf("MemoryRequestToLimitPercent=%d, CPURequestToLimitPercent=%d, LimitCPUToMemoryPercent=%d, ForceSelinuxRelabel=%t",
-		in.MemoryRequestToLimitPercent, in.CPURequestToLimitPercent, in.LimitCPUToMemoryPercent, in.ForceSelinuxRelabel)
+	return fmt.Sprintf("ForceSelinuxRelabel=%t, MemoryRequestToLimitPercent=%d, CPURequestToLimitPercent=%d, LimitCPUToMemoryPercent=%d, CPURequestToRequestPercent=%d",
+		in.ForceSelinuxRelabel, in.MemoryRequestToLimitPercent, in.CPURequestToLimitPercent, in.LimitCPUToMemoryPercent, in.CPURequestToRequestPercent)
 }
 
 func (in *PodResourceOverrideSpec) Validate() error {
@@ -27,6 +27,10 @@ func (in *PodResourceOverrideSpec) Validate() error {
 
 	if in.LimitCPUToMemoryPercent < 0 {
 		return errors.New("invalid value for LimitCPUToMemoryPercent, must be a positive value")
+	}
+
+	if in.CPURequestToRequestPercent < 0 || in.CPURequestToRequestPercent > 100 {
+		return errors.New("invalid value for CPURequestToRequestPercent, must be [0...100]")
 	}
 
 	return nil

--- a/pkg/apis/autoscaling/v1/override_types.go
+++ b/pkg/apis/autoscaling/v1/override_types.go
@@ -138,13 +138,17 @@ type PodResourceOverrideSpec struct {
 
 	// LimitCPUToMemoryPercent (if > 0) overrides the CPU limit to a ratio of the memory limit;
 	// 100% overrides CPU to 1 core per 1GiB of RAM. This is done before overriding the CPU request.
-	LimitCPUToMemoryPercent int64 `json:"limitCPUToMemoryPercent"`
+	LimitCPUToMemoryPercent int64 `json:"limitCPUToMemoryPercent,omitempty"`
 
 	// CPURequestToLimitPercent (if > 0) overrides CPU request to a percentage of CPU limit
-	CPURequestToLimitPercent int64 `json:"cpuRequestToLimitPercent"`
+	CPURequestToLimitPercent int64 `json:"cpuRequestToLimitPercent,omitempty"`
 
 	// MemoryRequestToLimitPercent (if > 0) overrides memory request to a percentage of memory limit
-	MemoryRequestToLimitPercent int64 `json:"memoryRequestToLimitPercent"`
+	MemoryRequestToLimitPercent int64 `json:"memoryRequestToLimitPercent,omitempty"`
+
+	// CPURequestToRequestPercent (if > 0) overrides CPU request to a percentage of the
+	// existing CPU request.
+	CPURequestToRequestPercent int64 `json:"cpuRequestToRequestPercent,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -7,7 +7,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 
 	autoscalingv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/autoscaling/v1"
@@ -46,11 +45,11 @@ func TestClusterResourceOverrideAdmissionWithOptIn(t *testing.T) {
 							},
 						},
 						SecurityContext: &corev1.SecurityContext{
-							AllowPrivilegeEscalation: pointer.BoolPtr(false),
+							AllowPrivilegeEscalation: ptr.To(false),
 							Capabilities: &corev1.Capabilities{
 								Drop: []corev1.Capability{"ALL"},
 							},
-							RunAsNonRoot: pointer.BoolPtr(true),
+							RunAsNonRoot: ptr.To(true),
 							SeccompProfile: &corev1.SeccompProfile{
 								Type: "RuntimeDefault",
 							},
@@ -72,11 +71,11 @@ func TestClusterResourceOverrideAdmissionWithOptIn(t *testing.T) {
 							},
 						},
 						SecurityContext: &corev1.SecurityContext{
-							AllowPrivilegeEscalation: pointer.BoolPtr(false),
+							AllowPrivilegeEscalation: ptr.To(false),
 							Capabilities: &corev1.Capabilities{
 								Drop: []corev1.Capability{"ALL"},
 							},
-							RunAsNonRoot: pointer.BoolPtr(true),
+							RunAsNonRoot: ptr.To(true),
 							SeccompProfile: &corev1.SeccompProfile{
 								Type: "RuntimeDefault",
 							},
@@ -126,11 +125,11 @@ func TestClusterResourceOverrideAdmissionWithOptIn(t *testing.T) {
 							"echo The app is running! && sleep 1",
 						},
 						SecurityContext: &corev1.SecurityContext{
-							AllowPrivilegeEscalation: pointer.BoolPtr(false),
+							AllowPrivilegeEscalation: ptr.To(false),
 							Capabilities: &corev1.Capabilities{
 								Drop: []corev1.Capability{"ALL"},
 							},
-							RunAsNonRoot: pointer.BoolPtr(true),
+							RunAsNonRoot: ptr.To(true),
 							SeccompProfile: &corev1.SeccompProfile{
 								Type: "RuntimeDefault",
 							},
@@ -153,11 +152,11 @@ func TestClusterResourceOverrideAdmissionWithOptIn(t *testing.T) {
 								corev1.ResourceCPU:    resource.MustParse("500m")},
 						},
 						SecurityContext: &corev1.SecurityContext{
-							AllowPrivilegeEscalation: pointer.BoolPtr(false),
+							AllowPrivilegeEscalation: ptr.To(false),
 							Capabilities: &corev1.Capabilities{
 								Drop: []corev1.Capability{"ALL"},
 							},
-							RunAsNonRoot: pointer.BoolPtr(true),
+							RunAsNonRoot: ptr.To(true),
 							SeccompProfile: &corev1.SeccompProfile{
 								Type: "RuntimeDefault",
 							},
@@ -214,11 +213,11 @@ func TestClusterResourceOverrideAdmissionWithOptIn(t *testing.T) {
 							},
 						},
 						SecurityContext: &corev1.SecurityContext{
-							AllowPrivilegeEscalation: pointer.BoolPtr(false),
+							AllowPrivilegeEscalation: ptr.To(false),
 							Capabilities: &corev1.Capabilities{
 								Drop: []corev1.Capability{"ALL"},
 							},
-							RunAsNonRoot: pointer.BoolPtr(true),
+							RunAsNonRoot: ptr.To(true),
 							SeccompProfile: &corev1.SeccompProfile{
 								Type: "RuntimeDefault",
 							},
@@ -273,11 +272,11 @@ func TestClusterResourceOverrideAdmissionWithOptIn(t *testing.T) {
 								corev1.ResourceCPU:    resource.MustParse("1000m")},
 						},
 						SecurityContext: &corev1.SecurityContext{
-							AllowPrivilegeEscalation: pointer.BoolPtr(false),
+							AllowPrivilegeEscalation: ptr.To(false),
 							Capabilities: &corev1.Capabilities{
 								Drop: []corev1.Capability{"ALL"},
 							},
-							RunAsNonRoot: pointer.BoolPtr(true),
+							RunAsNonRoot: ptr.To(true),
 							SeccompProfile: &corev1.SeccompProfile{
 								Type: "RuntimeDefault",
 							},
@@ -537,4 +536,58 @@ func TestClusterResourceOverrideDeploymentOverrides(t *testing.T) {
 	require.Equal(t, *deployment.Spec.Replicas, *deploymentOverrides.Replicas)
 	require.Equal(t, deployment.Spec.Template.Spec.NodeSelector, deploymentOverrides.NodeSelector)
 	require.Equal(t, deployment.Spec.Template.Spec.Tolerations, deploymentOverrides.Tolerations)
+}
+
+func TestClusterResourceOverrideAdmissionWithCPURequestToRequestPercent(t *testing.T) {
+	client := helper.NewClient(t, options.config)
+
+	f := &helper.PreCondition{Client: client.Kubernetes}
+	f.MustHaveAdmissionRegistrationV1(t)
+
+	configuration := autoscalingv1.PodResourceOverrideSpec{
+		CPURequestToRequestPercent:  50,
+		MemoryRequestToLimitPercent: 50,
+	}
+	override := autoscalingv1.PodResourceOverride{
+		Spec: configuration,
+	}
+
+	t.Logf("setting webhook configuration - %s", configuration.String())
+	current, changed := helper.EnsureAdmissionWebhook(t, client.Operator, "cluster", override, nil)
+	defer helper.RemoveAdmissionWebhook(t, client.Operator, current.GetName())
+
+	t.Log("waiting for webhook configuration to take effect")
+	current = helper.Wait(t, client.Operator, "cluster", helper.GetAvailableConditionFunc(current, changed))
+
+	f.MustHaveClusterResourceOverrideAdmissionConfiguration(t)
+	t.Log("webhook configuration has been set successfully")
+
+	ns, disposer := helper.NewNamespace(t, client.Kubernetes, "croe2e", true)
+	defer disposer.Dispose()
+
+	requirements := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("200m"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+
+	resourceWant := map[string]corev1.ResourceRequirements{
+		"app": {
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+			},
+		},
+	}
+
+	podGot, disposer := helper.NewPodWithResourceRequirement(t, client.Kubernetes, ns.GetName(), "app", requirements)
+	defer disposer.Dispose()
+
+	helper.MustMatchMemoryAndCPU(t, resourceWant, &podGot.Spec)
 }

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"github.com/stretchr/testify/require"
 
@@ -179,11 +179,11 @@ func NewPodWithResourceRequirement(t *testing.T, client kubernetes.Interface, na
 					},
 					Resources: requirements,
 					SecurityContext: &corev1.SecurityContext{
-						AllowPrivilegeEscalation: pointer.BoolPtr(false),
+						AllowPrivilegeEscalation: ptr.To(false),
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{"ALL"},
 						},
-						RunAsNonRoot: pointer.BoolPtr(true),
+						RunAsNonRoot: ptr.To(true),
 						SeccompProfile: &corev1.SeccompProfile{
 							Type: "RuntimeDefault",
 						},


### PR DESCRIPTION
Added CpuRequestToRequestPercent to the Operator

Jira: https://redhat.atlassian.net/browse/AUTOSCALE-705
Operand PR: https://github.com/openshift/cluster-resource-override-admission/pull/107

**Changes:**
- Added cpuRequestToRequestPercent field to CRD, operator types, String(), and Validate()
- Added omitempty to all override JSON tags so disabled fields are omitted instead of rejected by CRD validation
- Added e2e test for the new override
- Migrated deprecated pointer.BoolPtr calls to ptr.To

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `cpuRequestToRequestPercent` field to ClusterResourceOverride, enabling CPU request overrides as a percentage (1-100%) of existing request.

* **Documentation**
  * Updated Getting Started example with new CPU request override configuration.

* **Chores**
  * Updated Operator SDK from v1.42.0 to v1.42.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->