### PR TITLE
test: add dedicated upgrade test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,15 @@ e2e:
 	export GO111MODULE=on
 	$(GO) test -v -count=1 -timeout=15m ./test/e2e/... --kubeconfig=${KUBECONFIG} --namespace=$(OPERATOR_NAMESPACE)
 
+e2e-upgrade-pre:
+	$(GO) test -v -count=1 -timeout=10m ./test/e2e/... -run TestUpgradePre --kubeconfig=${KUBECONFIG} --namespace=$(OPERATOR_NAMESPACE)
+
+e2e-upgrade-post:
+	$(GO) test -v -count=1 -timeout=10m ./test/e2e/... -run TestUpgradePost --kubeconfig=${KUBECONFIG} --namespace=$(OPERATOR_NAMESPACE)
+
+e2e-upgrade-test:
+	./hack/upgrade-test.sh
+
 # apply OLM resources to deploy the operator.
 olm-apply:
 	$(KUBECTL) apply -n $(OPERATOR_NAMESPACE) -f $(OLM_MANIFESTS_DIR)

--- a/hack/OLM_UPGRADE.md
+++ b/hack/OLM_UPGRADE.md
@@ -1,0 +1,286 @@
+# OLM Upgrade Testing
+
+How to test an OLM-managed upgrade of ClusterResourceOverride from one
+version to another on an OpenShift cluster.
+
+The upgrade uses `operator-sdk run bundle` and `run bundle-upgrade`,
+which inject bundles into a transient in-cluster registry. OLM
+performs the actual upgrade (InstallPlan, CSV lifecycle, deployment
+rollout), but the catalog serving mechanism differs from production.
+The SDK constructs a synthetic FBC from bundle annotations and serves
+it via an ephemeral pod rather than a real catalog image.
+
+## Prerequisites
+
+- An OpenShift cluster with OLM running (`oc cluster-info` succeeds).
+- `podman`, `oc`, `operator-sdk` (v1.42+) installed locally.
+- A container registry you can push to (e.g. `quay.io/<user>`).
+  Log in with `podman login quay.io` before starting.
+
+You need the following container image repos to be public in your
+registry:
+
+| Repo | Purpose |
+|------|---------|
+| `<user>/clusterresourceoverride-operator` | Operator image |
+| `<user>/clusterresourceoverride` | Operand image |
+| `<user>/cro-bundle` | OLM bundle image |
+
+## Terminology
+
+| Term | Meaning |
+|------|---------|
+| OLD_VERSION | The version you are upgrading *from* (e.g. `4.18`). |
+| NEW_VERSION | The version you are upgrading *to* (e.g. `5.0`). |
+| Operator image | The controller binary (`cluster-resource-override-admission-operator`). |
+| Operand image | The admission webhook server (`clusterresourceoverride`). |
+| Bundle image | An OCI image containing the CSV + CRD + manifests for one version. |
+
+Throughout this document, substitute your own registry prefix for
+`quay.io/$USER`.
+
+---
+
+## Building the bundles
+
+You need two bundle images: one for the old version and one for the new.
+`generate-bundle.sh` builds the operator binary, operator image, bundle
+manifests, and bundle image in one shot.
+
+### Operand images
+
+The operand (admission webhook server) lives in a separate repo:
+[openshift/cluster-resource-override-admission](https://github.com/openshift/cluster-resource-override-admission).
+
+If you only need to test the operator upgrade mechanism, you can reuse
+a single existing operand image for both bundles (e.g.
+`quay.io/$USER/clusterresourceoverride:dev`).
+
+If you need to test differences between operand binaries across
+versions, clone the operand repo and build each version from its
+release branch:
+
+```bash
+cd /path/to/cluster-resource-override-admission
+git checkout release-${OLD_VERSION}
+podman build -t quay.io/$USER/clusterresourceoverride:v${OLD_VERSION} .
+podman push quay.io/$USER/clusterresourceoverride:v${OLD_VERSION}
+
+git checkout release-${NEW_VERSION}  # or main
+podman build -t quay.io/$USER/clusterresourceoverride:v${NEW_VERSION} .
+podman push quay.io/$USER/clusterresourceoverride:v${NEW_VERSION}
+```
+
+Then use the matching operand tag for each bundle's `OPERAND_IMG`
+below.
+
+### Generate the old version bundle
+
+Check out the branch or tag for the old version so the CSV already has
+the correct version strings and image references:
+
+```bash
+git checkout release-${OLD_VERSION}
+
+OPERATOR_IMG=quay.io/$USER/clusterresourceoverride-operator:v${OLD_VERSION} \
+OPERAND_IMG=quay.io/$USER/clusterresourceoverride:v${OLD_VERSION} \
+BUNDLE_IMG=quay.io/$USER/cro-bundle:v${OLD_VERSION} \
+./hack/generate-bundle.sh
+```
+
+### Generate the new version bundle
+
+Switch back to the branch with the new version:
+
+```bash
+git checkout main   # or your feature branch
+
+OPERATOR_IMG=quay.io/$USER/clusterresourceoverride-operator:v${NEW_VERSION} \
+OPERAND_IMG=quay.io/$USER/clusterresourceoverride:v${NEW_VERSION} \
+BUNDLE_IMG=quay.io/$USER/cro-bundle:v${NEW_VERSION} \
+./hack/generate-bundle.sh
+```
+
+---
+
+## Automated upgrade test
+
+The automated test creates a `ClusterResourceOverride` CR against the
+old version, validates that it works, upgrades to the new bundle, then
+verifies the CR survived the upgrade: status healthy, operand running,
+and webhook still mutating pods.
+
+### Running locally
+
+```bash
+OLD_BUNDLE=quay.io/$USER/cro-bundle:v${OLD_VERSION} \
+NEW_BUNDLE=quay.io/$USER/cro-bundle:v${NEW_VERSION} \
+KUBECONFIG=/path/to/kubeconfig \
+make e2e-upgrade-test
+```
+
+This runs `hack/upgrade-test.sh`, which orchestrates the full flow:
+
+1. Installs the old bundle with `operator-sdk run bundle`
+2. Runs `make e2e-upgrade-pre` (Go test: creates CR, validates old version)
+3. Upgrades with `operator-sdk run bundle-upgrade`
+4. Runs `make e2e-upgrade-post` (Go test: validates CR migration)
+5. Cleans up
+
+### Running individual steps
+
+You can run the pre and post checks independently against a cluster
+that already has the operator installed:
+
+```bash
+# After old version is installed:
+make e2e-upgrade-pre
+
+# After upgrade:
+make e2e-upgrade-post
+```
+
+### What the tests verify
+
+**`TestUpgradePre`** (before upgrade):
+
+- Creates the `ClusterResourceOverride` CR with the default config
+  (memoryRequestToLimitPercent=50, cpuRequestToLimitPercent=25,
+  limitCPUToMemoryPercent=200)
+- Waits for the CR to reach Available status
+- Checks the operand deployment is running
+- Verifies the MutatingWebhookConfiguration exists
+- Creates an opt-in namespace and pod, asserts resource mutation
+
+**`TestUpgradePost`** (after upgrade):
+
+- Verifies the CR still exists and is Available
+- Checks operand deployment has available replicas
+- Creates an opt-in namespace and pod, asserts resource mutation still
+  works
+- Removes the CR (cleanup for subsequent tests)
+
+As more upgrade-sensitive areas are identified (e.g. CRD field
+migrations, RBAC changes, new operand behavior), add assertions to
+`TestUpgradePre` and `TestUpgradePost` accordingly.
+
+### CI integration
+
+The same Go tests run in CI as part of the `e2e-aws-upgrade` job.
+See the [ci-operator config](https://github.com/openshift/release/blob/master/ci-operator/config/openshift/cluster-resource-override-admission-operator/openshift-cluster-resource-override-admission-operator-main.yaml).
+
+---
+
+## Manual upgrade procedure
+
+If you want to run the upgrade steps manually without the tests:
+
+### Install the old version
+
+```bash
+NAMESPACE=clusterresourceoverride-operator
+oc create namespace $NAMESPACE
+
+operator-sdk run bundle \
+  quay.io/$USER/cro-bundle:v${OLD_VERSION} \
+  -n $NAMESPACE \
+  --security-context-config restricted \
+  --timeout 10m
+```
+
+### Create the CR and verify
+
+```bash
+oc apply -f artifacts/example/clusterresourceoverride-cr.yaml
+sleep 10
+oc rollout status deployment/clusterresourceoverride -n $NAMESPACE --timeout=120s
+```
+
+### Upgrade
+
+```bash
+operator-sdk run bundle-upgrade \
+  quay.io/$USER/cro-bundle:v${NEW_VERSION} \
+  -n $NAMESPACE \
+  --security-context-config restricted \
+  --timeout 10m
+```
+
+### Verify
+
+```bash
+oc get csv -n $NAMESPACE
+oc get deployment clusterresourceoverride-operator -n $NAMESPACE \
+  -o jsonpath='{.spec.template.spec.containers[0].image}'
+oc rollout status deployment/clusterresourceoverride -n $NAMESPACE --timeout=120s
+```
+
+### Cleanup
+
+```bash
+oc delete clusterresourceoverride cluster
+operator-sdk cleanup -n $NAMESPACE clusterresourceoverride-operator
+oc delete namespace $NAMESPACE
+```
+
+---
+
+## Catalog-based upgrade (OCP console)
+
+The `operator-sdk run bundle` approach above is CLI-driven and uses a
+synthetic catalog. If you want to see both versions in the console's
+OperatorHub UI and trigger the upgrade by approving an InstallPlan
+(closer to how customers experience it), you can build a real FBC
+catalog image and deploy it via a CatalogSource.
+
+This requires one additional image repo in your registry:
+
+| Repo | Purpose |
+|------|---------|
+| `<user>/cro-catalog` | FBC catalog image |
+
+### Build the catalog
+
+After building both bundle images (see above), use `build-fbc.sh` to
+create a catalog containing both bundles with a `replaces` upgrade
+edge:
+
+```bash
+CATALOG_REPO=quay.io/$USER/cro-catalog \
+BUNDLE_REPO=quay.io/$USER/cro-bundle \
+PREV_VERSION=${OLD_VERSION} \
+./hack/build-fbc.sh
+```
+
+This generates `catalog/cro-fbc.yaml`, builds the catalog image, and
+pushes it.
+
+### Deploy the CatalogSource
+
+```bash
+CATALOG_IMG=quay.io/$USER/cro-catalog:v${NEW_VERSION} \
+./hack/deploy-catalogsource.sh
+```
+
+This creates a `CatalogSource` named `cro-fbc` in
+`openshift-marketplace` and waits for the PackageManifest to appear.
+
+### Installing and upgrading from the console
+
+Once the CatalogSource is deployed, go to OperatorHub in the OpenShift
+console and search for "ClusterResourceOverride". Select the one from
+the dev catalog, choose the starting version (e.g. v4.22), and install.
+When ready to upgrade, go to the installed operator's page and approve
+the upgrade to the newer version.
+
+---
+
+## Notes
+
+### Version strings in the CSV
+
+The CSV `metadata.name` must follow the pattern
+`clusterresourceoverride-operator.v<X.Y>.0` and `spec.version` must be
+`<X.Y>.0`. The `generate-bundle.sh` script substitutes image references
+but does not change the version string. When generating a bundle for a
+version different from the source tree, the two versions must be different.

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Orchestrates a local OLM upgrade test for ClusterResourceOverride.
+#
+# Required env vars:
+#   OLD_BUNDLE  - bundle image for the previous version
+#   NEW_BUNDLE  - bundle image for the new version
+#   KUBECONFIG  - path to cluster kubeconfig
+# 
+# Optional env vars:
+#   SKIP_CLEANUP - skip cleanup (default: false)
+# 
+# Usage:
+#   OLD_BUNDLE=quay.io/user/cro-bundle:v4.18 \
+#   NEW_BUNDLE=quay.io/user/cro-bundle:v5.0 \
+#   ./hack/upgrade-test.sh
+
+: "${OLD_BUNDLE:?OLD_BUNDLE must be set}"
+: "${NEW_BUNDLE:?NEW_BUNDLE must be set}"
+: "${KUBECONFIG:?KUBECONFIG must be set}"
+
+NAMESPACE=clusterresourceoverride-operator
+
+cleanup() {
+    if [[ "${SKIP_CLEANUP:-}" == "true" ]]; then
+        echo "--- Skipping cleanup (SKIP_CLEANUP=true) ---"
+        return
+    fi
+    echo "--- Cleaning up ---"
+    oc delete clusterresourceoverride cluster --ignore-not-found 2>/dev/null || true
+    sleep 5
+    operator-sdk cleanup -n "$NAMESPACE" clusterresourceoverride-operator 2>/dev/null || true
+    oc delete namespace "$NAMESPACE" --ignore-not-found 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "=== Step 1: Install old bundle ==="
+oc create namespace "$NAMESPACE" --dry-run=client -o yaml | oc apply -f -
+operator-sdk run bundle "$OLD_BUNDLE" -n "$NAMESPACE" \
+    --security-context-config restricted --timeout 10m
+
+echo "=== Step 2: Pre-upgrade check (create CR + validate old version) ==="
+make e2e-upgrade-pre
+
+echo "=== Step 3: Upgrade to new bundle ==="
+operator-sdk run bundle-upgrade "$NEW_BUNDLE" -n "$NAMESPACE" \
+    --security-context-config restricted --timeout 10m
+
+echo "=== Step 4: Post-upgrade check (validate migration) ==="
+make e2e-upgrade-post
+
+echo "=== Upgrade test passed ==="

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -1,0 +1,102 @@
+package e2e
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/client-go/kubernetes"
+
+	operatorv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/operator/v1"
+	"github.com/openshift/cluster-resource-override-admission-operator/test/helper"
+)
+
+// verifyAdmissionWebhook creates an opt-in namespace and a pod with known
+// resource limits, then asserts that the CRO webhook mutated the pod's
+// resources according to the default CR config (50/25/200).
+func verifyAdmissionWebhook(t *testing.T, kubeClient kubernetes.Interface) {
+	t.Helper()
+
+	ns, nsDisposer := helper.NewNamespace(t, kubeClient, "upgrade-verify", true)
+	defer nsDisposer.Dispose()
+
+	requirements := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+			corev1.ResourceCPU:    resource.MustParse("2000m"),
+		},
+	}
+	pod, podDisposer := helper.NewPodWithResourceRequirement(t, kubeClient, ns.Name, "test", requirements)
+	defer podDisposer.Dispose()
+
+	// limitCPUToMemoryPercent=200 -> CPU limit = 200% * 0.5Gi = 1000m
+	// memoryRequestToLimitPercent=50 -> memory request = 256Mi
+	// cpuRequestToLimitPercent=25 -> CPU request = 250m
+	resourceWant := map[string]corev1.ResourceRequirements{
+		"test": {
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+				corev1.ResourceCPU:    resource.MustParse("1000m"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+				corev1.ResourceCPU:    resource.MustParse("250m"),
+			},
+		},
+	}
+	helper.MustMatchMemoryAndCPU(t, resourceWant, &pod.Spec)
+}
+
+// TestUpgradePre creates the ClusterResourceOverride CR against the old
+// operator version and validates that the operand and webhook are functioning.
+// Run this after the old bundle is installed but before the upgrade.
+// The CR is intentionally not cleaned up so TestUpgradePost can verify it
+// survived the upgrade.
+func TestUpgradePre(t *testing.T) {
+	client := helper.NewClient(t, options.config)
+
+	override := operatorv1.PodResourceOverride{
+		Spec: operatorv1.PodResourceOverrideSpec{
+			LimitCPUToMemoryPercent:     200,
+			CPURequestToLimitPercent:    25,
+			MemoryRequestToLimitPercent: 50,
+		},
+	}
+	current, changed := helper.EnsureAdmissionWebhook(t, client.Operator, "cluster", override, nil)
+	// Do not defer RemoveAdmissionWebhook: the CR must survive for the post-upgrade check.
+
+	t.Log("waiting for CR to become Available")
+	helper.Wait(t, client.Operator, "cluster", helper.GetAvailableConditionFunc(current, changed))
+
+	t.Log("waiting for operand deployment rollout")
+	helper.WaitForDeploymentRollout(t, client.Kubernetes, operatorNamespace, "clusterresourceoverride")
+
+	f := &helper.PreCondition{Client: client.Kubernetes}
+	f.MustHaveClusterResourceOverrideAdmissionConfiguration(t)
+
+	t.Log("verifying webhook mutates pods correctly")
+	verifyAdmissionWebhook(t, client.Kubernetes)
+}
+
+// TestUpgradePost validates that a pre-existing ClusterResourceOverride CR
+// survived the bundle upgrade with its spec intact, status healthy, operand
+// running, and webhook still mutating pods.
+func TestUpgradePost(t *testing.T) {
+	client := helper.NewClient(t, options.config)
+
+	t.Log("verifying CR still exists after upgrade")
+	helper.GetClusterResourceOverride(t, client.Operator, "cluster")
+	defer helper.RemoveAdmissionWebhook(t, client.Operator, "cluster")
+
+	t.Log("waiting for CR to become Available after upgrade")
+	helper.Wait(t, client.Operator, "cluster", helper.IsAvailable)
+
+	t.Log("waiting for operand deployment rollout to complete")
+	// We have to wait for a full rollout because the operand has a pod anti-affinity that prevents pods from running on the same node.
+	// To prevent pods from getting stuck in rollout if there are not enough nodes, the Deployment rolloutStrategy has a maxSurge of 0.
+	// Therefore, old operand pods get removed before new ones start and the webhook can be briefly unreachable, and flake the test.
+	helper.WaitForDeploymentRollout(t, client.Kubernetes, operatorNamespace, "clusterresourceoverride")
+
+	t.Log("verifying webhook still mutates pods after upgrade")
+	verifyAdmissionWebhook(t, client.Kubernetes)
+}

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -381,6 +381,25 @@ func GetDeployment(t *testing.T, client kubernetes.Interface, namespace, name st
 	return deployment
 }
 
+func WaitForDeploymentRollout(t *testing.T, client kubernetes.Interface, namespace, name string) {
+	t.Helper()
+	err := wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		d, err := client.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return false, err
+			}
+			t.Logf("retrying: transient error getting deployment %s/%s: %v", namespace, name, err)
+			return false, nil
+		}
+		return d.Status.ObservedGeneration >= d.Generation &&
+			d.Status.UpdatedReplicas == *d.Spec.Replicas &&
+			d.Status.AvailableReplicas == *d.Spec.Replicas &&
+			d.Status.UnavailableReplicas == 0, nil
+	})
+	require.NoError(t, err, "timed out waiting for deployment %s/%s rollout", namespace, name)
+}
+
 var apiServerGVR = schema.GroupVersionResource{
 	Group:    "config.openshift.io",
 	Version:  "v1",


### PR DESCRIPTION
This commit adds a dedicated upgrade test suite to the repo. It is designed to run in sequence:
1. A previous operator bundle version is deployed to the cluster.
2. The TestUpgradePre step is run which creates a CRO object and makes sure it works.
3. The operator bundle upgrade step invoked by CI or the user.
4. The TestUpgradePost step is run which verify the same ClusterResourceOverride still works on a new pod
    - Also checks the operand is Available and fully rolled out before applying a test pod.

As we test more upgrade scenarios, we can put the code in these new Pre and Post e2e go test functions.

This commit also includes the workflow for manually invoking an upgrade and testing upgrades locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end upgrade testing commands for pre-upgrade, post-upgrade, and full upgrade validation.
  * Added a script to run an end-to-end upgrade test workflow end-to-end.
* **Tests**
  * Introduced an upgrade-focused E2E suite that verifies ClusterResourceOverride behavior and workload rollout before and after upgrades, with cleanup.
  * Added a deployment rollout wait helper to improve upgrade test reliability.
* **Documentation**
  * Added an OLM upgrade runbook with automated and manual upgrade instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->