### PR TITLE
AUTOSCALE-881: Add operator tolerations to run on master, add suggested namespace, auto-set control-plane node selector on standalone clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ IMAGE_VERSION := 5.0
 # this is the image tag of your custom dev image
 IMAGE_TAG := dev
 
-OPERATOR_NAMESPACE 			:= clusterresourceoverride-operator
+OPERATOR_NAMESPACE := openshift-cluster-resource-override
 OPERATOR_DEPLOYMENT_NAME 	:= clusterresourceoverride-operator
 
 export OLD_OPERATOR_IMAGE_URL_IN_CSV 	= quay.io/openshift/clusterresourceoverride-rhel8-operator:$(IMAGE_VERSION)

--- a/README.md
+++ b/README.md
@@ -114,14 +114,14 @@ status:
       apiVersion: v1
       kind: ConfigMap
       name: clusterresourceoverride-configuration
-      namespace: clusterresourceoverride-operator
+      namespace: openshift-cluster-resource-override
       resourceVersion: "60858"
       uid: a50a2095-bab9-4834-8be3-633028c35f9e
     deploymentRef:
       apiVersion: apps/v1
       kind: Deployment
       name: clusterresourceoverride
-      namespace: clusterresourceoverride-operator
+      namespace: openshift-cluster-resource-override
       resourceVersion: "61013"
       uid: 4f21e033-e806-48e0-b053-0bbb9d6f688d
     mutatingWebhookConfigurationRef:
@@ -134,7 +134,7 @@ status:
       apiVersion: v1
       kind: Service
       name: clusterresourceoverride
-      namespace: clusterresourceoverride-operator
+      namespace: openshift-cluster-resource-override
       resourceVersion: "60876"
       uid: 1e343ec2-8c71-4cbc-a236-8c9c3a791db2
   version: 1.0.0
@@ -229,10 +229,10 @@ kubectl apply -f artifacts/olm/catalog-source.yaml
 
 # wait for the CatalogSource object to be in 'READY' state.
 # one way to make sure is to check the 'status' block of the CatalogSource object
-kubectl -n clusterresourceoverride-operator get catalogsource clusterresourceoverride-catalog -o yaml
+kubectl -n openshift-cluster-resource-override get catalogsource clusterresourceoverride-catalog -o yaml
 
 # or, you can query to check if your operator has been registered
-kubectl -n clusterresourceoverride-operator get packagemanifests | grep clusterresourceoverride 
+kubectl -n openshift-cluster-resource-override get packagemanifests | grep clusterresourceoverride
 
 # at this point, you can install the operator from OperatorHub UI.
 # if you want to do it from the command line, then execute the following:

--- a/artifacts/deploy/000_operator-namespace.yaml
+++ b/artifacts/deploy/000_operator-namespace.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: clusterresourceoverride-operator
+  name: openshift-cluster-resource-override
 

--- a/artifacts/deploy/100_sa.yaml
+++ b/artifacts/deploy/100_sa.yaml
@@ -2,5 +2,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: clusterresourceoverride-operator
+  namespace: openshift-cluster-resource-override
   name: clusterresourceoverride-operator

--- a/artifacts/deploy/200_rbac.yaml
+++ b/artifacts/deploy/200_rbac.yaml
@@ -158,7 +158,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: clusterresourceoverride-operator
-  namespace: clusterresourceoverride-operator
+  namespace: openshift-cluster-resource-override
 rules:
   # to have the power to ensure RBAC for the operand
   - apiGroups:
@@ -233,13 +233,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: clusterresourceoverride-operator
-    namespace: clusterresourceoverride-operator
+    namespace: openshift-cluster-resource-override
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: clusterresourceoverride-operator
-  namespace: clusterresourceoverride-operator
+  namespace: openshift-cluster-resource-override
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -247,4 +247,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: clusterresourceoverride-operator
-    namespace: clusterresourceoverride-operator
+    namespace: openshift-cluster-resource-override

--- a/artifacts/deploy/300_deployment.yaml
+++ b/artifacts/deploy/300_deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: clusterresourceoverride-operator
+  namespace: openshift-cluster-resource-override
   name: clusterresourceoverride-operator
   labels:
     clusterresourceoverride.operator: "true"
@@ -60,3 +60,10 @@ spec:
             capabilities:
               drop:
               - ALL
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists

--- a/artifacts/namespace.yaml
+++ b/artifacts/namespace.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: clusterresourceoverride-operator
+  name: openshift-cluster-resource-override
 

--- a/bundle/manifests/clusterresourceoverride-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterresourceoverride-operator.clusterserviceversion.yaml
@@ -56,6 +56,7 @@ metadata:
     features.operators.openshift.io/token-auth-gcp: "false"
     healthIndex: B
     olm.skipRange: '>=4.3.0 <5.0.0'
+    operatorframework.io/suggested-namespace: openshift-cluster-resource-override
     operators.operatorframework.io/builder: operator-sdk-v1.42.2
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/openshift/cluster-resource-override-admission-operator
@@ -65,7 +66,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
   name: clusterresourceoverride-operator.v5.0.0
-  namespace: clusterresourceoverride-operator
+  namespace: openshift-cluster-resource-override
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
@@ -361,6 +362,13 @@ spec:
                 seccompProfile:
                   type: RuntimeDefault
               serviceAccountName: clusterresourceoverride-operator
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/master
+                operator: Exists
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/control-plane
+                operator: Exists
       permissions:
       - rules:
         - apiGroups:

--- a/doc/install-via-olm.md
+++ b/doc/install-via-olm.md
@@ -15,7 +15,7 @@ cat <<EOF | kubectl create -f -
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: clusterresourceoverride-operator
+  name: openshift-cluster-resource-override
 EOF
 ```
 
@@ -26,7 +26,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
   name: clusterresourceoverride-catalog
-  namespace: clusterresourceoverride-operator
+  namespace: openshift-cluster-resource-override
 spec:
   sourceType: grpc
   image: quay.io/redhat/clusterresourceoverride-registry@sha256:932d400cdc885266f07529f396a342d5b98d8a92dba3b76d9dddfdd3b1a294de
@@ -35,7 +35,7 @@ EOF
 
 Wait for the CatalogSource object to be in `READY` state. One way to make sure is to check the `status` block.
 ```bash
-$ watch kubectl -n clusterresourceoverride-operator get catalogsource clusterresourceoverride-catalog -o jsonpath='{.status.connectionState.lastObservedState}'
+$ watch kubectl -n openshift-cluster-resource-override get catalogsource clusterresourceoverride-catalog -o jsonpath='{.status.connectionState.lastObservedState}'
 READY
 ```
 
@@ -47,7 +47,7 @@ At this point, you can proceed to install the operator using
 #### Install via OperatorHub UI
 As highlighted in the snapshots, follow the steps below to install the `ClusterResourceOverride` operator.
 * Go to `OperatorHub`
-* Select `clusterresourceoverride-operator` Project.
+* Select `openshift-cluster-resource-override` Project (create, if necessary).
 * Select `Custom` for `Provider` type. (`ClusterResourceOverride` operator will appear in the result view)
 * Select the `ClusterResourceOverride` operator to install. Click `Install`, it will take you to the `Operator Subscription` page.
 * Click `Subscribe` with the default values populated by the UI. 
@@ -74,10 +74,10 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: clusterresourceoverride-operator
-  namespace: clusterresourceoverride-operator
+  namespace: openshift-cluster-resource-override
 spec:
   targetNamespaces:
-    - clusterresourceoverride-operator
+    - openshift-cluster-resource-override
 EOF
 ```
 
@@ -88,12 +88,12 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: clusterresourceoverride
-  namespace: clusterresourceoverride-operator
+  namespace: openshift-cluster-resource-override
 spec:
   channel: "4.4"
   name: clusterresourceoverride
   source: clusterresourceoverride-catalog
-  sourceNamespace: clusterresourceoverride-operator
+  sourceNamespace: openshift-cluster-resource-override
 EOF
 ```
 

--- a/hack/OLM_UPGRADE.md
+++ b/hack/OLM_UPGRADE.md
@@ -178,7 +178,7 @@ If you want to run the upgrade steps manually without the tests:
 ### Install the old version
 
 ```bash
-NAMESPACE=clusterresourceoverride-operator
+NAMESPACE=openshift-cluster-resource-override
 oc create namespace $NAMESPACE
 
 operator-sdk run bundle \

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 : "${NEW_BUNDLE:?NEW_BUNDLE must be set}"
 : "${KUBECONFIG:?KUBECONFIG must be set}"
 
-NAMESPACE=clusterresourceoverride-operator
+NAMESPACE=openshift-cluster-resource-override
 
 cleanup() {
     if [[ "${SKIP_CLEANUP:-}" == "true" ]]; then

--- a/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
+++ b/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
@@ -44,6 +44,7 @@ metadata:
     categories: OpenShift Optional
     certifiedLevel: Primed
     olm.skipRange: ">=4.3.0 <5.0.0"
+    operatorframework.io/suggested-namespace: openshift-cluster-resource-override
     containerImage: quay.io/openshift/clusterresourceoverride-rhel8-operator:5.0
     createdAt: 2019/11/15
     description: An operator to manage the OpenShift ClusterResourceOverride Mutating Admission Webhook Server
@@ -62,7 +63,7 @@ metadata:
     operatorframework.io/arch.s390x: supported
     operatorframework.io/arch.ppc64le: supported
   name: clusterresourceoverride-operator.v5.0.0
-  namespace: clusterresourceoverride-operator
+  namespace: openshift-cluster-resource-override
 spec:
   customresourcedefinitions:
     owned:
@@ -430,6 +431,13 @@ spec:
                   runAsNonRoot: true
                   seccompProfile:
                     type: RuntimeDefault
+                tolerations:
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/master
+                    operator: Exists
+                  - effect: NoSchedule
+                    key: node-role.kubernetes.io/control-plane
+                    operator: Exists
   installModes:
     - supported: true
       type: OwnNamespace

--- a/pkg/asset/deployment.go
+++ b/pkg/asset/deployment.go
@@ -12,16 +12,9 @@ var tolerationSeconds = int64(120)
 
 var DefaultReplicas int32 = 2
 
-var DefaultNodeSelector = map[string]string{
-	"node-role.kubernetes.io/master": "",
-}
+var DefaultNodeSelector = map[string]string{}
 
 var DefaultTolerations = []corev1.Toleration{
-	{
-		Key:      "node-role.kubernetes.io/master",
-		Operator: corev1.TolerationOpExists,
-		Effect:   corev1.TaintEffectNoSchedule,
-	},
 	{
 		Key:               "node.kubernetes.io/unreachable",
 		Operator:          corev1.TolerationOpExists,

--- a/pkg/clusterresourceoverride/controller.go
+++ b/pkg/clusterresourceoverride/controller.go
@@ -36,6 +36,7 @@ type Options struct {
 	Client         *operatorruntime.Client
 	RuntimeContext operatorruntime.OperandContext
 	Lister         *secondarywatch.Lister
+	IsStandalone   bool
 }
 
 func New(options *Options) (c controller.Interface, e operatorruntime.Enqueuer, err error) {
@@ -84,6 +85,7 @@ func New(options *Options) (c controller.Interface, e operatorruntime.Enqueuer, 
 		Asset:           operandAsset,
 		Deploy:          d,
 		DynamicClient:   options.Client.RawDynamic,
+		IsStandalone:    options.IsStandalone,
 	})
 
 	c = &clusterResourceOverrideController{

--- a/pkg/clusterresourceoverride/internal/handlers/context.go
+++ b/pkg/clusterresourceoverride/internal/handlers/context.go
@@ -23,6 +23,7 @@ type Options struct {
 	Asset           *asset.Asset
 	Deploy          deploy.Interface
 	DynamicClient   dynamic.Interface
+	IsStandalone    bool
 }
 
 type ReconcileRequestContext struct {

--- a/pkg/clusterresourceoverride/internal/handlers/deploy.go
+++ b/pkg/clusterresourceoverride/internal/handlers/deploy.go
@@ -28,24 +28,26 @@ import (
 
 func NewDeploymentHandler(o *Options) *deploymentHandler {
 	return &deploymentHandler{
-		client:     o.Client.Kubernetes,
-		dynamic:    o.Client.Dynamic,
-		deployment: ensurer.NewDeploymentEnsurer(o.Client.Dynamic),
-		asset:      o.Asset,
-		lister:     o.SecondaryLister,
-		deploy:     o.Deploy,
-		dynClient:  o.DynamicClient,
+		client:       o.Client.Kubernetes,
+		dynamic:      o.Client.Dynamic,
+		deployment:   ensurer.NewDeploymentEnsurer(o.Client.Dynamic),
+		asset:        o.Asset,
+		lister:       o.SecondaryLister,
+		deploy:       o.Deploy,
+		dynClient:    o.DynamicClient,
+		isStandalone: o.IsStandalone,
 	}
 }
 
 type deploymentHandler struct {
-	client     kubernetes.Interface
-	deployment *ensurer.DeploymentEnsurer
-	dynamic    dynamicclient.Ensurer
-	lister     *secondarywatch.Lister
-	asset      *asset.Asset
-	deploy     deploy.Interface
-	dynClient  dynamic.Interface
+	client       kubernetes.Interface
+	deployment   *ensurer.DeploymentEnsurer
+	dynamic      dynamicclient.Ensurer
+	lister       *secondarywatch.Lister
+	asset        *asset.Asset
+	deploy       deploy.Interface
+	dynClient    dynamic.Interface
+	isStandalone bool
 }
 
 func (c *deploymentHandler) Handle(ctx *ReconcileRequestContext, original *operatorv1.ClusterResourceOverride) (current *operatorv1.ClusterResourceOverride, result controllerreconciler.Result, handleErr error) {
@@ -182,11 +184,30 @@ func (c *deploymentHandler) ApplyToToPodTemplate(context *ReconcileRequestContex
 		// Replaces nodeSelector, if specified in the CR
 		if len(cro.Spec.DeploymentOverrides.NodeSelector) > 0 {
 			podTemplateSpec.Spec.NodeSelector = cro.Spec.DeploymentOverrides.NodeSelector
+		} else if c.isStandalone {
+			// On standalone clusters, schedule on control-plane nodes
+			podTemplateSpec.Spec.NodeSelector = map[string]string{
+				"node-role.kubernetes.io/control-plane": "",
+			}
 		}
 
 		// Replaces tolerations, if specified in the CR
 		if len(cro.Spec.DeploymentOverrides.Tolerations) > 0 {
 			podTemplateSpec.Spec.Tolerations = cro.Spec.DeploymentOverrides.Tolerations
+		} else if c.isStandalone {
+			// On standalone clusters, tolerate both master (legacy) and control-plane taints
+			podTemplateSpec.Spec.Tolerations = append(podTemplateSpec.Spec.Tolerations,
+				corev1.Toleration{
+					Key:      "node-role.kubernetes.io/master",
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+				corev1.Toleration{
+					Key:      "node-role.kubernetes.io/control-plane",
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			)
 		}
 
 		if len(podTemplateSpec.Spec.Containers) > 0 {

--- a/pkg/clusterresourceoverride/internal/handlers/deploy_test.go
+++ b/pkg/clusterresourceoverride/internal/handlers/deploy_test.go
@@ -1,0 +1,253 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	operatorv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/operator/v1"
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/asset"
+	operatorruntime "github.com/openshift/cluster-resource-override-admission-operator/pkg/runtime"
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/tlsprofile"
+)
+
+// minimalHandler builds a deploymentHandler with only the asset field set, which
+// is all that ApplyToToPodTemplate and ApplyToDeploymentObject require.
+func minimalHandler(t *testing.T) *deploymentHandler {
+	t.Helper()
+	ctx := operatorruntime.NewOperandContext("clusterresourceoverride", "test-ns", "cluster", "test-image:latest", "1.0.0")
+	return &deploymentHandler{
+		asset: asset.New(ctx),
+	}
+}
+
+// minimalStandaloneHandler builds a deploymentHandler with isStandalone=true.
+func minimalStandaloneHandler(t *testing.T) *deploymentHandler {
+	t.Helper()
+	h := minimalHandler(t)
+	h.isStandalone = true
+	return h
+}
+
+// minimalCRO returns a ClusterResourceOverride with the GVK set (required by
+// SetController) and a known configuration hash.
+func minimalCRO() *operatorv1.ClusterResourceOverride {
+	cro := &operatorv1.ClusterResourceOverride{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+	}
+	cro.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   operatorv1.GroupName,
+		Version: operatorv1.GroupVersion,
+		Kind:    operatorv1.ClusterResourceOverrideKind,
+	})
+	cro.Status.Hash.Configuration = "testhash"
+	return cro
+}
+
+func podTemplateWithBaseArgs() *corev1.PodTemplateSpec {
+	return &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "clusterresourceoverride",
+					Args: []string{
+						"--secure-port=9400",
+						"--tls-cert-file=/var/serving-cert/tls.crt",
+						"--tls-private-key-file=/var/serving-cert/tls.key",
+						"--v=8",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestApplyToToPodTemplate_EmptyTLSArgs(t *testing.T) {
+	h := minimalHandler(t)
+	ctx := NewReconcileRequestContext(operatorruntime.NewOperandContext("clusterresourceoverride", "test-ns", "cluster", "img", "1.0"))
+	cro := minimalCRO()
+	pt := podTemplateWithBaseArgs()
+
+	applier := h.ApplyToToPodTemplate(ctx, cro, tlsprofile.Args{})
+	applier.Apply(pt)
+
+	args := pt.Spec.Containers[0].Args
+	for _, arg := range args {
+		assert.NotContains(t, arg, "--tls-min-version", "empty TLS args must not add --tls-min-version")
+		assert.NotContains(t, arg, "--tls-cipher-suites", "empty TLS args must not add --tls-cipher-suites")
+	}
+}
+
+func TestApplyToToPodTemplate_MinVersionOnly(t *testing.T) {
+	h := minimalHandler(t)
+	ctx := NewReconcileRequestContext(operatorruntime.NewOperandContext("clusterresourceoverride", "test-ns", "cluster", "img", "1.0"))
+	cro := minimalCRO()
+	pt := podTemplateWithBaseArgs()
+
+	applier := h.ApplyToToPodTemplate(ctx, cro, tlsprofile.Args{MinVersion: "VersionTLS12"})
+	applier.Apply(pt)
+
+	args := pt.Spec.Containers[0].Args
+	assert.Contains(t, args, "--tls-min-version=VersionTLS12")
+	for _, arg := range args {
+		assert.NotContains(t, arg, "--tls-cipher-suites", "only MinVersion was set; --tls-cipher-suites must be absent")
+	}
+}
+
+func TestApplyToToPodTemplate_CipherSuitesOnly(t *testing.T) {
+	h := minimalHandler(t)
+	ctx := NewReconcileRequestContext(operatorruntime.NewOperandContext("clusterresourceoverride", "test-ns", "cluster", "img", "1.0"))
+	cro := minimalCRO()
+	pt := podTemplateWithBaseArgs()
+
+	ciphers := "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+	applier := h.ApplyToToPodTemplate(ctx, cro, tlsprofile.Args{CipherSuites: ciphers})
+	applier.Apply(pt)
+
+	args := pt.Spec.Containers[0].Args
+	assert.Contains(t, args, "--tls-cipher-suites="+ciphers)
+	for _, arg := range args {
+		assert.NotContains(t, arg, "--tls-min-version", "only CipherSuites was set; --tls-min-version must be absent")
+	}
+}
+
+func TestApplyToToPodTemplate_BothTLSArgs(t *testing.T) {
+	h := minimalHandler(t)
+	ctx := NewReconcileRequestContext(operatorruntime.NewOperandContext("clusterresourceoverride", "test-ns", "cluster", "img", "1.0"))
+	cro := minimalCRO()
+	pt := podTemplateWithBaseArgs()
+
+	tlsArgs := tlsprofile.Args{
+		MinVersion:   "VersionTLS13",
+		CipherSuites: "TLS_AES_128_GCM_SHA256",
+	}
+	applier := h.ApplyToToPodTemplate(ctx, cro, tlsArgs)
+	applier.Apply(pt)
+
+	args := pt.Spec.Containers[0].Args
+	assert.Contains(t, args, "--tls-min-version=VersionTLS13")
+	assert.Contains(t, args, "--tls-cipher-suites=TLS_AES_128_GCM_SHA256")
+}
+
+func TestApplyToToPodTemplate_BaseArgsUnchanged(t *testing.T) {
+	h := minimalHandler(t)
+	ctx := NewReconcileRequestContext(operatorruntime.NewOperandContext("clusterresourceoverride", "test-ns", "cluster", "img", "1.0"))
+	cro := minimalCRO()
+	pt := podTemplateWithBaseArgs()
+	baseArgs := make([]string, len(pt.Spec.Containers[0].Args))
+	copy(baseArgs, pt.Spec.Containers[0].Args)
+
+	applier := h.ApplyToToPodTemplate(ctx, cro, tlsprofile.Args{MinVersion: "VersionTLS12"})
+	applier.Apply(pt)
+
+	// All original base args must still be present
+	for _, base := range baseArgs {
+		assert.Contains(t, pt.Spec.Containers[0].Args, base, "base arg %q must not be removed", base)
+	}
+}
+
+func TestApplyToDeploymentObject_TLSHashAnnotation(t *testing.T) {
+	h := minimalHandler(t)
+	ctx := NewReconcileRequestContext(operatorruntime.NewOperandContext("clusterresourceoverride", "test-ns", "cluster", "img", "1.0"))
+	cro := minimalCRO()
+
+	tlsArgs := tlsprofile.Args{MinVersion: "VersionTLS12", CipherSuites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"}
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{},
+		},
+	}
+
+	applier := h.ApplyToDeploymentObject(ctx, cro, tlsArgs)
+	applier.Apply(deployment)
+
+	annotationKey := h.asset.Values().TLSProfileHashAnnotationKey
+	require.NotEmpty(t, annotationKey)
+	assert.Equal(t, tlsArgs.Hash(), deployment.GetAnnotations()[annotationKey],
+		"TLS profile hash annotation must match Args.Hash()")
+}
+
+func TestApplyToDeploymentObject_EmptyTLSArgsProducesEmptyAnnotation(t *testing.T) {
+	h := minimalHandler(t)
+	ctx := NewReconcileRequestContext(operatorruntime.NewOperandContext("clusterresourceoverride", "test-ns", "cluster", "img", "1.0"))
+	cro := minimalCRO()
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{},
+		},
+	}
+
+	applier := h.ApplyToDeploymentObject(ctx, cro, tlsprofile.Args{})
+	applier.Apply(deployment)
+
+	annotationKey := h.asset.Values().TLSProfileHashAnnotationKey
+	assert.Equal(t, "", deployment.GetAnnotations()[annotationKey],
+		"empty TLS args must produce empty annotation so existing deployments are not spuriously re-ensured")
+}
+
+func TestApplyToToPodTemplate_StandaloneNoUserOverride(t *testing.T) {
+	h := minimalStandaloneHandler(t)
+	ctx := NewReconcileRequestContext(operatorruntime.NewOperandContext("clusterresourceoverride", "test-ns", "cluster", "img", "1.0"))
+	cro := minimalCRO()
+	pt := podTemplateWithBaseArgs()
+
+	applier := h.ApplyToToPodTemplate(ctx, cro, tlsprofile.Args{})
+	applier.Apply(pt)
+
+	assert.Equal(t, map[string]string{"node-role.kubernetes.io/control-plane": ""}, pt.Spec.NodeSelector,
+		"standalone cluster should get control-plane node selector")
+
+	hasMasterToleration := false
+	hasControlPlaneToleration := false
+	for _, tol := range pt.Spec.Tolerations {
+		if tol.Key == "node-role.kubernetes.io/master" && tol.Effect == corev1.TaintEffectNoSchedule {
+			hasMasterToleration = true
+		}
+		if tol.Key == "node-role.kubernetes.io/control-plane" && tol.Effect == corev1.TaintEffectNoSchedule {
+			hasControlPlaneToleration = true
+		}
+	}
+	assert.True(t, hasMasterToleration, "standalone cluster should tolerate master NoSchedule taint")
+	assert.True(t, hasControlPlaneToleration, "standalone cluster should tolerate control-plane NoSchedule taint")
+}
+
+func TestApplyToToPodTemplate_ExternalNoUserOverride(t *testing.T) {
+	h := minimalHandler(t) // isStandalone defaults to false
+	ctx := NewReconcileRequestContext(operatorruntime.NewOperandContext("clusterresourceoverride", "test-ns", "cluster", "img", "1.0"))
+	cro := minimalCRO()
+	pt := podTemplateWithBaseArgs()
+
+	applier := h.ApplyToToPodTemplate(ctx, cro, tlsprofile.Args{})
+	applier.Apply(pt)
+
+	assert.Empty(t, pt.Spec.NodeSelector, "HCP cluster should not set a control-plane node selector")
+
+	for _, tol := range pt.Spec.Tolerations {
+		assert.NotEqual(t, "node-role.kubernetes.io/master", tol.Key, "HCP cluster should not add master toleration")
+		assert.NotEqual(t, "node-role.kubernetes.io/control-plane", tol.Key, "HCP cluster should not add control-plane toleration")
+	}
+}
+
+func TestApplyToToPodTemplate_UserOverrideOnStandalone(t *testing.T) {
+	h := minimalStandaloneHandler(t)
+	ctx := NewReconcileRequestContext(operatorruntime.NewOperandContext("clusterresourceoverride", "test-ns", "cluster", "img", "1.0"))
+	cro := minimalCRO()
+	cro.Spec.DeploymentOverrides.NodeSelector = map[string]string{"node-role.kubernetes.io/worker": ""}
+	cro.Spec.DeploymentOverrides.Tolerations = []corev1.Toleration{
+		{Key: "custom", Operator: corev1.TolerationOpEqual, Value: "val", Effect: corev1.TaintEffectNoSchedule},
+	}
+	pt := podTemplateWithBaseArgs()
+
+	applier := h.ApplyToToPodTemplate(ctx, cro, tlsprofile.Args{})
+	applier.Apply(pt)
+
+	assert.Equal(t, map[string]string{"node-role.kubernetes.io/worker": ""}, pt.Spec.NodeSelector,
+		"user override should take precedence over auto control-plane selector")
+	assert.Equal(t, cro.Spec.DeploymentOverrides.Tolerations, pt.Spec.Tolerations,
+		"user override should take precedence over auto tolerations")
+}

--- a/pkg/infrastructure/infrastructure.go
+++ b/pkg/infrastructure/infrastructure.go
@@ -1,0 +1,40 @@
+package infrastructure
+
+import (
+	"context"
+
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
+)
+
+var InfrastructureGVR = schema.GroupVersionResource{
+	Group:    "config.openshift.io",
+	Version:  "v1",
+	Resource: "infrastructures",
+}
+
+// IsStandalone fetches the cluster Infrastructure resource and returns true
+// if the control plane topology is NOT external (i.e. not a Hosted Control
+// Plane cluster). On error it logs a warning and defaults to true (standalone)
+// for backward compatibility.
+func IsStandalone(ctx context.Context, dynClient dynamic.Interface) bool {
+	obj, err := dynClient.Resource(InfrastructureGVR).Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		klog.Warningf("Failed to fetch Infrastructure resource, assuming standalone: %v", err)
+		return true
+	}
+
+	infra := &configv1.Infrastructure{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, infra); err != nil {
+		klog.Warningf("Failed to convert Infrastructure resource, assuming standalone: %v", err)
+		return true
+	}
+
+	topology := infra.Status.ControlPlaneTopology
+	klog.Infof("Detected control plane topology: %s", topology)
+	return topology != configv1.ExternalTopologyMode
+}

--- a/pkg/infrastructure/infrastructure_test.go
+++ b/pkg/infrastructure/infrastructure_test.go
@@ -1,0 +1,69 @@
+package infrastructure
+
+import (
+	"context"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func makeFakeDynClient(t *testing.T, topology configv1.TopologyMode) *dynamicfake.FakeDynamicClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, configv1.AddToScheme(scheme))
+	infra := &configv1.Infrastructure{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "config.openshift.io/v1", Kind: "Infrastructure"},
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Status: configv1.InfrastructureStatus{
+			ControlPlaneTopology: topology,
+		},
+	}
+	return dynamicfake.NewSimpleDynamicClient(scheme, infra)
+}
+
+func TestIsStandalone(t *testing.T) {
+	tests := []struct {
+		name     string
+		topology configv1.TopologyMode
+		want     bool
+	}{
+		{
+			name:     "HighlyAvailable is standalone",
+			topology: configv1.HighlyAvailableTopologyMode,
+			want:     true,
+		},
+		{
+			name:     "SingleReplica is standalone",
+			topology: configv1.SingleReplicaTopologyMode,
+			want:     true,
+		},
+		{
+			name:     "External (HCP) is not standalone",
+			topology: configv1.ExternalTopologyMode,
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dynClient := makeFakeDynClient(t, tt.topology)
+			got := IsStandalone(context.Background(), dynClient)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsStandalone_NotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, configv1.AddToScheme(scheme))
+	dynClient := dynamicfake.NewSimpleDynamicClient(scheme)
+
+	// Should default to true (standalone) when Infrastructure CR is missing
+	got := IsStandalone(context.Background(), dynClient)
+	assert.True(t, got, "should default to standalone when Infrastructure resource is not found")
+}

--- a/pkg/operator/run.go
+++ b/pkg/operator/run.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/infrastructure"
 	"github.com/openshift/cluster-resource-override-admission-operator/pkg/secondarywatch"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
@@ -57,6 +58,8 @@ func (r *runner) Run(config *Config, errorCh chan<- error) {
 	context := runtime.NewOperandContext(config.Name, config.Namespace, DefaultCR, config.OperandImage, config.OperandVersion)
 	apiregistrationv1.AddToScheme(scheme.Scheme)
 
+	standalone := infrastructure.IsStandalone(config.ShutdownContext, clients.RawDynamic)
+
 	// create lister(s) for secondary resources
 	lister, starter := secondarywatch.New(&secondarywatch.Options{
 		Client:              clients,
@@ -72,6 +75,7 @@ func (r *runner) Run(config *Config, errorCh chan<- error) {
 		RuntimeContext: context,
 		Client:         clients,
 		Lister:         lister,
+		IsStandalone:   standalone,
 	})
 	if err != nil {
 		errorCh <- fmt.Errorf("failed to create controller - %s", err.Error())

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	operatorNamespace = "clusterresourceoverride-operator"
+	operatorNamespace = "openshift-cluster-resource-override"
 	configMapName     = "clusterresourceoverride-configuration"
 )
 


### PR DESCRIPTION
When no nodeSelector is provided in the ClusterResourceOverride CR's deploymentOverrides, the operator now detects the cluster's control plane topology at startup via the Infrastructure resource and then takes the following action:

- Standalone clusters: sets node-role.kubernetes.io/control-plane node selector and tolerates both master (legacy) and control-plane NoSchedule taints for seamless transition.
- Hosted Control Plane (External topology): no control-plane node selector is set, allowing the operand to schedule on worker nodes.

User-provided nodeSelector and tolerations in the CR always take precedence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of standalone vs externally managed cluster topologies.
  * Improved standalone scheduling defaults by setting control-plane node selection/tolerations when no user overrides are provided.
  * Added an OLM “suggested installation namespace” annotation.

* **Bug Fixes**
  * Ensured user-defined scheduling overrides are preserved.
  * Enabled operator scheduling onto tainted control-plane nodes where applicable.
  * Avoided default master-node scheduling for external clusters.

* **Documentation / Packaging**
  * Updated installation, OLM, and e2e references to use `openshift-cluster-resource-override` instead of the previous namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->