### PR TITLE
AUTOSCALE-863-866: Add ResourceOverride controller, RBAC, and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,8 @@ deploy:
 	mkdir -p $(KUBE_MANIFESTS_DIR)
 	cp -r $(KUBE_MANIFESTS_SOURCE)/* $(KUBE_MANIFESTS_DIR)/
 	cp manifests/stable/clusterresourceoverride.crd.yaml $(KUBE_MANIFESTS_DIR)/
+	cp manifests/stable/resourceoverride.crd.yaml $(KUBE_MANIFESTS_DIR)/
+	cp manifests/stable/resourceoverride-rbac.yaml $(KUBE_MANIFESTS_DIR)/
 	cp $(ARTIFACTS)/registry-env.yaml $(KUBE_MANIFESTS_DIR)/
 
 	$(REGISTRY_SETUP_BINARY) --mode=$(DEPLOY_MODE) --olm=false --configmap=$(CONFIGMAP_ENV_FILE)
@@ -130,6 +132,10 @@ undeploy-olm: delete-test-pod delete-cro-cr
 	$(KUBECTL) delete -n $(OPERATOR_NAMESPACE) -f $(OPERATOR_REGISTRY_MANIFESTS_DIR) --ignore-not-found
 	$(KUBECTL) delete -n $(OPERATOR_NAMESPACE) -f $(OLM_MANIFESTS_DIR) --ignore-not-found
 	$(KUBECTL) delete -n $(OPERATOR_NAMESPACE) -f $(KUBE_MANIFESTS_DIR) --ignore-not-found
+
+# run unit tests
+unit-test:
+	$(GO) test -v -count=1 $(GO_TEST_PACKAGES)
 
 # run e2e test(s)
 e2e:

--- a/artifacts/deploy/200_rbac.yaml
+++ b/artifacts/deploy/200_rbac.yaml
@@ -121,6 +121,15 @@ rules:
     - list
     - watch
 
+  # to grant power to the operand to create and patch events
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+
   # to grant power to the operand to delegate authentication and authorization
   - apiGroups:
     - authentication.k8s.io

--- a/bundle/manifests/clusterresourceoverride-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterresourceoverride-operator.clusterserviceversion.yaml
@@ -44,7 +44,7 @@ metadata:
     categories: OpenShift Optional
     certifiedLevel: Primed
     containerImage: quay.io/openshift/clusterresourceoverride-rhel8-operator:5.0
-    createdAt: "2026-07-01T20:49:09Z"
+    createdAt: "2026-07-30T21:02:32Z"
     description: An operator to manage the OpenShift ClusterResourceOverride Mutating
       Admission Webhook Server
     features.operators.openshift.io/disconnected: "true"
@@ -273,6 +273,13 @@ spec:
           - get
           - list
           - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
         - apiGroups:
           - authentication.k8s.io
           resources:

--- a/bundle/manifests/resourceoverrides-admin-edit_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/resourceoverrides-admin-edit_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: resourceoverrides-admin-edit
+rules:
+- apiGroups:
+  - autoscaling.openshift.io
+  resources:
+  - resourceoverrides
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/bundle/manifests/resourceoverrides-view_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/resourceoverrides-view_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: resourceoverrides-view
+rules:
+- apiGroups:
+  - autoscaling.openshift.io
+  resources:
+  - resourceoverrides
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
+++ b/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
@@ -292,6 +292,15 @@ spec:
             - list
             - watch
 
+        # to grant power to the operand to emit events for resourceoverride conflicts
+        - apiGroups:
+            - ''
+          resources:
+            - events
+          verbs:
+            - create
+            - patch
+
         # to have the power to manage configuration for admission webhook
         - apiGroups:
             - admissionregistration.k8s.io

--- a/manifests/stable/resourceoverride-rbac.yaml
+++ b/manifests/stable/resourceoverride-rbac.yaml
@@ -1,0 +1,38 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: resourceoverrides-admin-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups:
+  - autoscaling.openshift.io
+  resources:
+  - resourceoverrides
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: resourceoverrides-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups:
+  - autoscaling.openshift.io
+  resources:
+  - resourceoverrides
+  verbs:
+  - get
+  - list
+  - watch

--- a/pkg/asset/rbac.go
+++ b/pkg/asset/rbac.go
@@ -151,7 +151,7 @@ func (s *rbac) New() []*RBACItem {
 							"watch",
 						},
 					},
-					// to give power to the operand to watch Namespace and LimitRange
+					// to give power to the operand to watch prioritylevelconfigurations and flowschemas
 					{
 						APIGroups: []string{
 							"flowcontrol.apiserver.k8s.io",
@@ -164,6 +164,33 @@ func (s *rbac) New() []*RBACItem {
 							"get",
 							"list",
 							"watch",
+						},
+					},
+					// to give power to the operand to watch resourceoverrides
+					{
+						APIGroups: []string{
+							"autoscaling.openshift.io",
+						},
+						Resources: []string{
+							"resourceoverrides",
+						},
+						Verbs: []string{
+							"get",
+							"list",
+							"watch",
+						},
+					},
+					// to give power to the operand to emit events for resourceoverride conflicts
+					{
+						APIGroups: []string{
+							"",
+						},
+						Resources: []string{
+							"events",
+						},
+						Verbs: []string{
+							"create",
+							"patch",
 						},
 					},
 				},

--- a/pkg/clusterresourceoverride/internal/condition/builder.go
+++ b/pkg/clusterresourceoverride/internal/condition/builder.go
@@ -117,7 +117,7 @@ func (b *Builder) WithCondition(desired *operatorv1.ClusterResourceOverrideCondi
 }
 
 func (b *Builder) init() {
-	if b.status == nil {
+	if b.status.Conditions == nil {
 		b.status.Conditions = []operatorv1.ClusterResourceOverrideCondition{}
 	}
 }

--- a/pkg/controller/handler.go
+++ b/pkg/controller/handler.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewEventHandler returns a cache.ResourceEventHandler appropriate for
-// reconciliation of ClusterResourceOverride object(s).
+// reconciliation of ClusterResourceOverride and ResourceOverride object(s).
 func NewEventHandler(queue workqueue.RateLimitingInterface) EventHandler {
 	return EventHandler{
 		queue: queue,

--- a/pkg/operator/run.go
+++ b/pkg/operator/run.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/openshift/cluster-resource-override-admission-operator/pkg/clusterresourceoverride"
 	"github.com/openshift/cluster-resource-override-admission-operator/pkg/controller"
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/resourceoverride"
 	"github.com/openshift/cluster-resource-override-admission-operator/pkg/runtime"
 )
 
@@ -26,7 +27,7 @@ const (
 	// Default worker count is 1.
 	DefaultWorkerCount = 1
 
-	// Default ResyncPeriod for primary (ClusterResourceOverride objects)
+	// Default ResyncPeriod for primary resources (ClusterResourceOverride and ResourceOverride objects)
 	DefaultResyncPeriodPrimaryResource = 1 * time.Hour
 
 	// Default ResyncPeriod for all secondary resources that the operator manages.
@@ -69,7 +70,7 @@ func (r *runner) Run(config *Config, errorCh chan<- error) {
 	})
 
 	// start the controllers
-	c, enqueuer, err := clusterresourceoverride.New(&clusterresourceoverride.Options{
+	cro, enqueuer, err := clusterresourceoverride.New(&clusterresourceoverride.Options{
 		ResyncPeriod:   DefaultResyncPeriodPrimaryResource,
 		Workers:        DefaultWorkerCount,
 		RuntimeContext: context,
@@ -78,20 +79,38 @@ func (r *runner) Run(config *Config, errorCh chan<- error) {
 		IsStandalone:   standalone,
 	})
 	if err != nil {
-		errorCh <- fmt.Errorf("failed to create controller - %s", err.Error())
+		errorCh <- fmt.Errorf("failed to create clusterresourceoverride controller - %s", err.Error())
 		return
 	}
 
-	// setup watches for secondary resources
+	ro, err := resourceoverride.New(&resourceoverride.Options{
+		ResyncPeriod: DefaultResyncPeriodPrimaryResource,
+		Workers:      DefaultWorkerCount,
+		Client:       clients,
+	})
+	if err != nil {
+		errorCh <- fmt.Errorf("failed to create resourceoverride controller - %s", err.Error())
+		return
+	}
+
+	// setup watches for ClusterResourceOverride secondary resources
 	if err := starter.Start(enqueuer, config.ShutdownContext); err != nil {
 		errorCh <- fmt.Errorf("failed to start watch on secondary resources - %s", err.Error())
 		return
 	}
 
-	runner := controller.NewRunner()
-	runnerErrorCh := make(chan error, 0)
-	go runner.Run(config.ShutdownContext, c, runnerErrorCh)
-	if err := <-runnerErrorCh; err != nil {
+	croRunner := controller.NewRunner()
+	croRunnerErrorCh := make(chan error, 0)
+	go croRunner.Run(config.ShutdownContext, cro, croRunnerErrorCh)
+	if err := <-croRunnerErrorCh; err != nil {
+		errorCh <- err
+		return
+	}
+
+	roRunner := controller.NewRunner()
+	roRunnerErrorCh := make(chan error, 0)
+	go roRunner.Run(config.ShutdownContext, ro, roRunnerErrorCh)
+	if err := <-roRunnerErrorCh; err != nil {
 		errorCh <- err
 		return
 	}
@@ -104,9 +123,10 @@ func (r *runner) Run(config *Config, errorCh chan<- error) {
 	go http.ListenAndServe(":8080", healthMux)
 
 	errorCh <- nil
-	klog.V(1).Infof("operator is waiting for controller(s) to be done")
+	klog.V(1).Infof("operator is waiting for controllers to be done")
 
-	<-runner.Done()
+	<-croRunner.Done()
+	<-roRunner.Done()
 }
 
 func (r *runner) Done() <-chan struct{} {

--- a/pkg/resourceoverride/controller.go
+++ b/pkg/resourceoverride/controller.go
@@ -1,0 +1,100 @@
+package resourceoverride
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	controllerreconciler "sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	autoscalingv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/autoscaling/v1"
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/controller"
+	listers "github.com/openshift/cluster-resource-override-admission-operator/pkg/generated/listers/autoscaling/v1"
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/resourceoverride/internal/reconciler"
+	operatorruntime "github.com/openshift/cluster-resource-override-admission-operator/pkg/runtime"
+)
+
+const (
+	ControllerName = "resourceoverride"
+)
+
+type Options struct {
+	ResyncPeriod time.Duration
+	Workers      int
+	Client       *operatorruntime.Client
+}
+
+func New(options *Options) (c controller.Interface, err error) {
+	if options == nil || options.Client == nil {
+		err = errors.New("Invalid input to controller.New")
+		return
+	}
+
+	client := options.Client.Operator
+	watcher := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return client.AutoscalingV1().ResourceOverrides("").List(context.TODO(), options)
+		},
+
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return client.AutoscalingV1().ResourceOverrides("").Watch(context.TODO(), options)
+		},
+	}
+
+	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+	store, informer := cache.NewInformerWithOptions(cache.InformerOptions{
+		ListerWatcher: watcher,
+		ObjectType:    &autoscalingv1.ResourceOverride{},
+		Handler:       controller.NewEventHandler(queue),
+		ResyncPeriod:  options.ResyncPeriod,
+		Indexers:      cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+	})
+
+	lister := listers.NewResourceOverrideLister(store.(cache.Indexer))
+
+	reconciler := reconciler.NewReconciler(client, lister)
+
+	c = &resourceOverrideController{
+		workers:    options.Workers,
+		queue:      queue,
+		informer:   informer,
+		reconciler: reconciler,
+		lister:     lister,
+	}
+
+	return
+}
+
+type resourceOverrideController struct {
+	workers    int
+	queue      workqueue.RateLimitingInterface
+	informer   cache.Controller
+	reconciler controllerreconciler.Reconciler
+	lister     listers.ResourceOverrideLister
+}
+
+func (c *resourceOverrideController) Name() string {
+	return ControllerName
+}
+
+func (c *resourceOverrideController) WorkerCount() int {
+	return c.workers
+}
+
+func (c *resourceOverrideController) Queue() workqueue.RateLimitingInterface {
+	return c.queue
+}
+
+func (c *resourceOverrideController) Informer() cache.Controller {
+	return c.informer
+}
+
+func (c *resourceOverrideController) Reconciler() controllerreconciler.Reconciler {
+	return c.reconciler
+}

--- a/pkg/resourceoverride/controller_test.go
+++ b/pkg/resourceoverride/controller_test.go
@@ -1,0 +1,68 @@
+package resourceoverride
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/generated/clientset/versioned/fake"
+	operatorruntime "github.com/openshift/cluster-resource-override-admission-operator/pkg/runtime"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name        string
+		options     *Options
+		wantErr     bool
+		wantName    string
+		wantWorkers int
+	}{
+		{
+			name:    "nil options",
+			options: nil,
+			wantErr: true,
+		},
+		{
+			name: "nil client",
+			options: &Options{
+				ResyncPeriod: 10 * time.Minute,
+				Workers:      1,
+				Client:       nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid options",
+			options: &Options{
+				ResyncPeriod: 10 * time.Minute,
+				Workers:      2,
+				Client: &operatorruntime.Client{
+					Operator: fake.NewSimpleClientset(),
+				},
+			},
+			wantErr:     false,
+			wantName:    ControllerName,
+			wantWorkers: 2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c, err := New(test.options)
+			if test.wantErr {
+				require.Error(t, err)
+				require.Nil(t, c)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, c)
+			require.Equal(t, test.wantName, c.Name())
+			require.Equal(t, test.wantWorkers, c.WorkerCount())
+			require.NotNil(t, c.Queue())
+			require.NotNil(t, c.Informer())
+			require.NotNil(t, c.Reconciler())
+		})
+	}
+}

--- a/pkg/resourceoverride/internal/condition/builder.go
+++ b/pkg/resourceoverride/internal/condition/builder.go
@@ -1,0 +1,100 @@
+package condition
+
+import (
+	autoscalingv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock"
+)
+
+type Builder struct {
+	clock  clock.Clock
+	status *autoscalingv1.ResourceOverrideStatus
+}
+
+func NewBuilderWithStatus(status *autoscalingv1.ResourceOverrideStatus) *Builder {
+	return &Builder{
+		clock:  clock.RealClock{},
+		status: status,
+	}
+}
+
+func (b *Builder) init() {
+	if b.status.Conditions == nil {
+		b.status.Conditions = []autoscalingv1.ResourceOverrideCondition{}
+	}
+}
+
+func (b *Builder) WithValidationFailure(reason string, message string) (builder *Builder) {
+	b.init()
+
+	desired := &autoscalingv1.ResourceOverrideCondition{
+		Type:               autoscalingv1.ValidationFailure,
+		Status:             corev1.ConditionTrue,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.NewTime(b.clock.Now()),
+	}
+	b.WithCondition(desired)
+
+	return b
+}
+
+func (b *Builder) WithValidationCleared() (builder *Builder) {
+	b.init()
+
+	desired := &autoscalingv1.ResourceOverrideCondition{
+		Type:               autoscalingv1.ValidationFailure,
+		Status:             corev1.ConditionFalse,
+		LastTransitionTime: metav1.NewTime(b.clock.Now()),
+	}
+	b.WithCondition(desired)
+
+	return b
+}
+
+func (b *Builder) WithCondition(desired *autoscalingv1.ResourceOverrideCondition) {
+	if desired == nil {
+		return
+	}
+
+	current := Find(b.status, desired.Type)
+	if current == nil {
+		b.status.Conditions = append(b.status.Conditions, *desired)
+		return
+	}
+
+	if Equal(desired, current) {
+		return
+	}
+
+	current.Reason = desired.Reason
+	current.Message = desired.Message
+	current.Status = desired.Status
+	current.LastTransitionTime = desired.LastTransitionTime
+}
+
+func Find(status *autoscalingv1.ResourceOverrideStatus, conditionType autoscalingv1.ResourceOverrideConditionType) *autoscalingv1.ResourceOverrideCondition {
+	for i := range status.Conditions {
+		c := &status.Conditions[i]
+		if c.Type == conditionType {
+			return c
+		}
+	}
+
+	return nil
+}
+
+// Equal returns true if the two given conditions are equal.
+// We deem two conditions equal if Type, Status, Reason and Message are a match
+// (despite LastTransitionTime being different).
+func Equal(this, that *autoscalingv1.ResourceOverrideCondition) bool {
+	if this.Type == that.Type &&
+		this.Status == that.Status &&
+		this.Reason == that.Reason &&
+		this.Message == that.Message {
+		return true
+	}
+
+	return false
+}

--- a/pkg/resourceoverride/internal/condition/builder_test.go
+++ b/pkg/resourceoverride/internal/condition/builder_test.go
@@ -1,0 +1,167 @@
+package condition
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	autoscalingv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/autoscaling/v1"
+)
+
+func TestWithValidationFailure(t *testing.T) {
+	status := &autoscalingv1.ResourceOverrideStatus{}
+	builder := NewBuilderWithStatus(status)
+
+	builder.WithValidationFailure(autoscalingv1.InvalidParameters, "invalid spec")
+
+	require.Len(t, status.Conditions, 1)
+	cond := &status.Conditions[0]
+	require.Equal(t, autoscalingv1.ValidationFailure, cond.Type)
+	require.Equal(t, corev1.ConditionTrue, cond.Status)
+	require.Equal(t, autoscalingv1.InvalidParameters, cond.Reason)
+	require.Equal(t, "invalid spec", cond.Message)
+	require.False(t, cond.LastTransitionTime.IsZero())
+}
+
+func TestWithValidationCleared(t *testing.T) {
+	status := &autoscalingv1.ResourceOverrideStatus{}
+	builder := NewBuilderWithStatus(status)
+
+	builder.WithValidationCleared()
+
+	require.Len(t, status.Conditions, 1)
+	cond := &status.Conditions[0]
+	require.Equal(t, autoscalingv1.ValidationFailure, cond.Type)
+	require.Equal(t, corev1.ConditionFalse, cond.Status)
+	require.Empty(t, cond.Reason)
+	require.Empty(t, cond.Message)
+}
+
+func TestWithConditionAppends(t *testing.T) {
+	status := &autoscalingv1.ResourceOverrideStatus{}
+	builder := NewBuilderWithStatus(status)
+	builder.init()
+
+	desired := &autoscalingv1.ResourceOverrideCondition{
+		Type:   autoscalingv1.ValidationFailure,
+		Status: corev1.ConditionTrue,
+		Reason: autoscalingv1.InvalidParameters,
+	}
+	builder.WithCondition(desired)
+
+	require.Len(t, status.Conditions, 1)
+	require.Equal(t, autoscalingv1.InvalidParameters, status.Conditions[0].Reason)
+}
+
+func TestWithConditionUpdatesInPlace(t *testing.T) {
+	status := &autoscalingv1.ResourceOverrideStatus{
+		Conditions: []autoscalingv1.ResourceOverrideCondition{
+			{
+				Type:   autoscalingv1.ValidationFailure,
+				Status: corev1.ConditionTrue,
+				Reason: autoscalingv1.InvalidParameters,
+			},
+		},
+	}
+	builder := NewBuilderWithStatus(status)
+
+	updated := &autoscalingv1.ResourceOverrideCondition{
+		Type:   autoscalingv1.ValidationFailure,
+		Status: corev1.ConditionFalse,
+		Reason: "",
+	}
+	builder.WithCondition(updated)
+
+	require.Len(t, status.Conditions, 1)
+	require.Equal(t, corev1.ConditionFalse, status.Conditions[0].Status)
+	require.Empty(t, status.Conditions[0].Reason)
+}
+
+func TestWithConditionNoOpWhenEqual(t *testing.T) {
+	status := &autoscalingv1.ResourceOverrideStatus{
+		Conditions: []autoscalingv1.ResourceOverrideCondition{
+			{
+				Type:    autoscalingv1.ValidationFailure,
+				Status:  corev1.ConditionTrue,
+				Reason:  autoscalingv1.InvalidParameters,
+				Message: "bad spec",
+			},
+		},
+	}
+	builder := NewBuilderWithStatus(status)
+
+	same := &autoscalingv1.ResourceOverrideCondition{
+		Type:    autoscalingv1.ValidationFailure,
+		Status:  corev1.ConditionTrue,
+		Reason:  autoscalingv1.InvalidParameters,
+		Message: "bad spec",
+	}
+	builder.WithCondition(same)
+
+	require.Len(t, status.Conditions, 1)
+}
+
+func TestWithConditionNilIsNoOp(t *testing.T) {
+	status := &autoscalingv1.ResourceOverrideStatus{}
+	builder := NewBuilderWithStatus(status)
+
+	builder.WithCondition(nil)
+
+	require.Empty(t, status.Conditions)
+}
+
+func TestFind(t *testing.T) {
+	t.Run("returns nil when not found", func(t *testing.T) {
+		status := &autoscalingv1.ResourceOverrideStatus{}
+		result := Find(status, autoscalingv1.ValidationFailure)
+		require.Nil(t, result)
+	})
+
+	t.Run("returns correct pointer from multiple conditions", func(t *testing.T) {
+		status := &autoscalingv1.ResourceOverrideStatus{
+			Conditions: []autoscalingv1.ResourceOverrideCondition{
+				{
+					Type:   "Other",
+					Status: corev1.ConditionFalse,
+					Reason: "should-not-match",
+				},
+				{
+					Type:   autoscalingv1.ValidationFailure,
+					Status: corev1.ConditionTrue,
+					Reason: autoscalingv1.ExemptNamespace,
+				},
+			},
+		}
+		result := Find(status, autoscalingv1.ValidationFailure)
+		require.NotNil(t, result)
+		require.Equal(t, autoscalingv1.ExemptNamespace, result.Reason)
+	})
+}
+
+func TestEqual(t *testing.T) {
+	now := metav1.Now()
+	earlier := metav1.NewTime(now.Add(-1 * time.Hour))
+
+	a := &autoscalingv1.ResourceOverrideCondition{
+		Type:               autoscalingv1.ValidationFailure,
+		Status:             corev1.ConditionTrue,
+		Reason:             autoscalingv1.InvalidParameters,
+		Message:            "bad",
+		LastTransitionTime: now,
+	}
+	b := &autoscalingv1.ResourceOverrideCondition{
+		Type:               autoscalingv1.ValidationFailure,
+		Status:             corev1.ConditionTrue,
+		Reason:             autoscalingv1.InvalidParameters,
+		Message:            "bad",
+		LastTransitionTime: earlier,
+	}
+	require.True(t, Equal(a, b), "should be equal despite different LastTransitionTime")
+
+	b.Message = "different"
+	require.False(t, Equal(a, b))
+}

--- a/pkg/resourceoverride/internal/reconciler/reconciler.go
+++ b/pkg/resourceoverride/internal/reconciler/reconciler.go
@@ -1,0 +1,104 @@
+package reconciler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	autoscalingv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/autoscaling/v1"
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/generated/clientset/versioned"
+	autoscalingv1listers "github.com/openshift/cluster-resource-override-admission-operator/pkg/generated/listers/autoscaling/v1"
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/resourceoverride/internal/condition"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
+	controllerreconciler "sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var (
+	ResourceOverrideGVK = schema.GroupVersionKind{
+		Group:   autoscalingv1.GroupName,
+		Version: autoscalingv1.GroupVersion,
+		Kind:    autoscalingv1.ResourceOverrideKind,
+	}
+)
+
+type reconciler struct {
+	client  versioned.Interface
+	lister  autoscalingv1listers.ResourceOverrideLister
+	updater *StatusUpdater
+}
+
+func NewReconciler(client versioned.Interface, lister autoscalingv1listers.ResourceOverrideLister) *reconciler {
+	return &reconciler{
+		client: client,
+		lister: lister,
+		updater: &StatusUpdater{
+			client: client,
+		},
+	}
+}
+
+func (r *reconciler) Reconcile(ctx context.Context, request controllerreconciler.Request) (result controllerreconciler.Result, err error) {
+	klog.V(4).Infof("key=%s new request for reconcile", request.Name)
+
+	original, getErr := r.lister.ResourceOverrides(request.Namespace).Get(request.Name)
+	if getErr != nil {
+		if k8serrors.IsNotFound(getErr) {
+			klog.V(4).Infof("[reconciler] key=%s object has been deleted - %s", request.Name, getErr.Error())
+			return
+		}
+
+		// Otherwise, we will requeue.
+		klog.Errorf("[reconciler] key=%s unexpected error - %s", request.Name, getErr.Error())
+		err = getErr
+		return
+	}
+
+	copy := original.DeepCopy()
+	copy.SetGroupVersionKind(ResourceOverrideGVK)
+
+	Validate(copy)
+
+	err = r.updater.Update(original, copy)
+	if err != nil {
+		klog.Errorf("[reconciler] key=%s failed to update status - %s", request.Name, err.Error())
+	}
+
+	return
+}
+
+func Validate(current *autoscalingv1.ResourceOverride) {
+	builder := condition.NewBuilderWithStatus(&current.Status)
+
+	if isExemptNamespace(current.Namespace) {
+		builder.WithValidationFailure(autoscalingv1.ExemptNamespace, fmt.Sprintf("resourceoverride %s/%s is in an exempt namespace", current.Namespace, current.Name))
+		return
+	}
+
+	validationErr := current.Spec.PodResourceOverride.Validate()
+	if validationErr != nil {
+		builder.WithValidationFailure(autoscalingv1.InvalidParameters, fmt.Sprintf("resourceoverride %s/%s has invalid parameters: %s", current.Namespace, current.Name, validationErr.Error()))
+		return
+	}
+
+	if current.Spec.PodSelector != nil {
+		if _, selectorErr := metav1.LabelSelectorAsSelector(current.Spec.PodSelector); selectorErr != nil {
+			builder.WithValidationFailure(autoscalingv1.InvalidParameters, fmt.Sprintf("resourceoverride %s/%s has invalid podSelector field: %s", current.Namespace, current.Name, selectorErr.Error()))
+			return
+		}
+	}
+
+	builder.WithValidationCleared()
+}
+
+func isExemptNamespace(namespace string) bool {
+	switch namespace {
+	case "openshift", "kube", "kubernetes":
+		return true
+	}
+	return strings.HasPrefix(namespace, "openshift-") ||
+		strings.HasPrefix(namespace, "kube-") ||
+		strings.HasPrefix(namespace, "kubernetes-")
+}

--- a/pkg/resourceoverride/internal/reconciler/reconciler_test.go
+++ b/pkg/resourceoverride/internal/reconciler/reconciler_test.go
@@ -1,0 +1,240 @@
+package reconciler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+	controllerreconciler "sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	autoscalingv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/autoscaling/v1"
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/generated/clientset/versioned/fake"
+	autoscalingv1listers "github.com/openshift/cluster-resource-override-admission-operator/pkg/generated/listers/autoscaling/v1"
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/resourceoverride/internal/condition"
+)
+
+func TestIsExemptNamespace(t *testing.T) {
+	tests := []struct {
+		namespace string
+		want      bool
+	}{
+		{"default", false},
+		{"my-namespace", false},
+		{"mykube-system", false},
+		{"openshift", true},
+		{"openshift-monitoring", true},
+		{"openshift-operators", true},
+		{"kube", true},
+		{"kube-system", true},
+		{"kube-public", true},
+		{"kubernetes", true},
+		{"kubernetes-dashboard", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.namespace, func(t *testing.T) {
+			got := isExemptNamespace(test.namespace)
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name       string
+		ro         *autoscalingv1.ResourceOverride
+		wantStatus corev1.ConditionStatus
+		wantReason string
+	}{
+		{
+			name: "valid spec",
+			ro: &autoscalingv1.ResourceOverride{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: autoscalingv1.ResourceOverrideSpec{
+					PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+						MemoryRequestToLimitPercent: 50,
+						CPURequestToLimitPercent:    25,
+					},
+				},
+			},
+			wantStatus: corev1.ConditionFalse,
+			wantReason: "",
+		},
+		{
+			name: "valid spec with nil podSelector",
+			ro: &autoscalingv1.ResourceOverride{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: autoscalingv1.ResourceOverrideSpec{
+					PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+						MemoryRequestToLimitPercent: 50,
+					},
+					PodSelector: nil,
+				},
+			},
+			wantStatus: corev1.ConditionFalse,
+			wantReason: "",
+		},
+		{
+			name: "exempt namespace",
+			ro: &autoscalingv1.ResourceOverride{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "openshift-monitoring",
+				},
+				Spec: autoscalingv1.ResourceOverrideSpec{
+					PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+						MemoryRequestToLimitPercent: 50,
+					},
+				},
+			},
+			wantStatus: corev1.ConditionTrue,
+			wantReason: autoscalingv1.ExemptNamespace,
+		},
+		{
+			name: "invalid spec - out of range",
+			ro: &autoscalingv1.ResourceOverride{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: autoscalingv1.ResourceOverrideSpec{
+					PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+						MemoryRequestToLimitPercent: 200,
+					},
+				},
+			},
+			wantStatus: corev1.ConditionTrue,
+			wantReason: autoscalingv1.InvalidParameters,
+		},
+		{
+			name: "invalid podSelector",
+			ro: &autoscalingv1.ResourceOverride{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: autoscalingv1.ResourceOverrideSpec{
+					PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+						MemoryRequestToLimitPercent: 50,
+					},
+					PodSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "app",
+								Operator: metav1.LabelSelectorOperator("InvalidOperator"),
+							},
+						},
+					},
+				},
+			},
+			wantStatus: corev1.ConditionTrue,
+			wantReason: autoscalingv1.InvalidParameters,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			Validate(test.ro)
+
+			cond := condition.Find(&test.ro.Status, autoscalingv1.ValidationFailure)
+			require.NotNil(t, cond)
+			require.Equal(t, test.wantStatus, cond.Status)
+			require.Equal(t, test.wantReason, cond.Reason)
+		})
+	}
+}
+
+func TestReconcile(t *testing.T) {
+	t.Run("valid RO updates status", func(t *testing.T) {
+		ro := &autoscalingv1.ResourceOverride{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-ro",
+				Namespace: "default",
+			},
+			Spec: autoscalingv1.ResourceOverrideSpec{
+				PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+					MemoryRequestToLimitPercent: 50,
+				},
+			},
+		}
+
+		fakeClient := fake.NewSimpleClientset(ro)
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		indexer.Add(ro)
+		lister := autoscalingv1listers.NewResourceOverrideLister(indexer)
+
+		r := NewReconciler(fakeClient, lister)
+		result, err := r.Reconcile(context.TODO(), controllerreconciler.Request{
+			NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-ro"},
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, controllerreconciler.Result{}, result)
+
+		updated, getErr := fakeClient.AutoscalingV1().ResourceOverrides("default").Get(context.TODO(), "test-ro", metav1.GetOptions{})
+		require.NoError(t, getErr)
+
+		cond := condition.Find(&updated.Status, autoscalingv1.ValidationFailure)
+		require.NotNil(t, cond)
+		require.Equal(t, corev1.ConditionFalse, cond.Status)
+	})
+
+	t.Run("not found returns no error", func(t *testing.T) {
+		fakeClient := fake.NewSimpleClientset()
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		lister := autoscalingv1listers.NewResourceOverrideLister(indexer)
+
+		r := NewReconciler(fakeClient, lister)
+		_, err := r.Reconcile(context.TODO(), controllerreconciler.Request{
+			NamespacedName: types.NamespacedName{Namespace: "default", Name: "nonexistent"},
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid RO updates status with failure", func(t *testing.T) {
+		ro := &autoscalingv1.ResourceOverride{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-ro-invalid",
+				Namespace: "default",
+			},
+			Spec: autoscalingv1.ResourceOverrideSpec{
+				PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+					MemoryRequestToLimitPercent: 200,
+				},
+			},
+		}
+
+		fakeClient := fake.NewSimpleClientset(ro)
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		indexer.Add(ro)
+		lister := autoscalingv1listers.NewResourceOverrideLister(indexer)
+
+		r := NewReconciler(fakeClient, lister)
+		result, err := r.Reconcile(context.TODO(), controllerreconciler.Request{
+			NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-ro-invalid"},
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, controllerreconciler.Result{}, result)
+
+		updated, getErr := fakeClient.AutoscalingV1().ResourceOverrides("default").Get(context.TODO(), "test-ro-invalid", metav1.GetOptions{})
+		require.NoError(t, getErr)
+
+		cond := condition.Find(&updated.Status, autoscalingv1.ValidationFailure)
+		require.NotNil(t, cond)
+		require.Equal(t, corev1.ConditionTrue, cond.Status)
+		require.Equal(t, autoscalingv1.InvalidParameters, cond.Reason)
+	})
+}

--- a/pkg/resourceoverride/internal/reconciler/updater.go
+++ b/pkg/resourceoverride/internal/reconciler/updater.go
@@ -1,0 +1,27 @@
+package reconciler
+
+import (
+	"context"
+	"reflect"
+
+	autoscalingv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/autoscaling/v1"
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/generated/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// StatusUpdater updates the status of a ResourceOverride resource.
+type StatusUpdater struct {
+	client versioned.Interface
+}
+
+// Update updates the status of a ResourceOverride resource.
+// If the status inside of the desired object is equal to that of the observed then
+// the function does not make an update call.
+func (u *StatusUpdater) Update(observed, desired *autoscalingv1.ResourceOverride) error {
+	if reflect.DeepEqual(&observed.Status, &desired.Status) {
+		return nil
+	}
+
+	_, err := u.client.AutoscalingV1().ResourceOverrides(desired.GetNamespace()).UpdateStatus(context.TODO(), desired, metav1.UpdateOptions{})
+	return err
+}

--- a/pkg/resourceoverride/internal/reconciler/updater_test.go
+++ b/pkg/resourceoverride/internal/reconciler/updater_test.go
@@ -1,0 +1,89 @@
+package reconciler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stesting "k8s.io/client-go/testing"
+
+	autoscalingv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/autoscaling/v1"
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/generated/clientset/versioned/fake"
+)
+
+func TestStatusUpdater(t *testing.T) {
+	t.Run("identical status makes no API call", func(t *testing.T) {
+		status := autoscalingv1.ResourceOverrideStatus{
+			Conditions: []autoscalingv1.ResourceOverrideCondition{
+				{
+					Type:   autoscalingv1.ValidationFailure,
+					Status: corev1.ConditionFalse,
+				},
+			},
+		}
+
+		observed := &autoscalingv1.ResourceOverride{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Status:     status,
+		}
+		desired := &autoscalingv1.ResourceOverride{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Status:     status,
+		}
+
+		fakeClient := fake.NewSimpleClientset(observed)
+		updater := &StatusUpdater{client: fakeClient}
+
+		err := updater.Update(observed, desired)
+		require.NoError(t, err)
+
+		for _, action := range fakeClient.Actions() {
+			require.NotEqual(t, "update", action.GetVerb(), "expected no update call for identical status")
+		}
+	})
+
+	t.Run("different status calls UpdateStatus", func(t *testing.T) {
+		observed := &autoscalingv1.ResourceOverride{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Status: autoscalingv1.ResourceOverrideStatus{
+				Conditions: []autoscalingv1.ResourceOverrideCondition{
+					{
+						Type:   autoscalingv1.ValidationFailure,
+						Status: corev1.ConditionFalse,
+					},
+				},
+			},
+		}
+		desired := &autoscalingv1.ResourceOverride{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Status: autoscalingv1.ResourceOverrideStatus{
+				Conditions: []autoscalingv1.ResourceOverrideCondition{
+					{
+						Type:   autoscalingv1.ValidationFailure,
+						Status: corev1.ConditionTrue,
+						Reason: autoscalingv1.InvalidParameters,
+					},
+				},
+			},
+		}
+
+		fakeClient := fake.NewSimpleClientset(observed)
+		updater := &StatusUpdater{client: fakeClient}
+
+		err := updater.Update(observed, desired)
+		require.NoError(t, err)
+
+		var found bool
+		for _, action := range fakeClient.Actions() {
+			if action.GetVerb() == "update" {
+				updateAction := action.(k8stesting.UpdateAction)
+				require.Equal(t, "resourceoverrides", updateAction.GetResource().Resource)
+				require.Equal(t, "status", updateAction.GetSubresource())
+				found = true
+			}
+		}
+		require.True(t, found, "expected UpdateStatus call for different status")
+	})
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,14 +1,18 @@
 package e2e
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
+	autoscalingv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/autoscaling/v1"
 	operatorv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/operator/v1"
 	"github.com/openshift/cluster-resource-override-admission-operator/test/helper"
 )
@@ -588,6 +592,421 @@ func TestClusterResourceOverrideAdmissionWithCPURequestToRequestPercent(t *testi
 
 	podGot, disposer := helper.NewPodWithResourceRequirement(t, client.Kubernetes, ns.GetName(), "app", requirements)
 	defer disposer.Dispose()
+
+	helper.MustMatchMemoryAndCPU(t, resourceWant, &podGot.Spec)
+}
+
+func TestResourceOverrideAdmissionOverridesPod(t *testing.T) {
+	client := helper.NewClient(t, options.config)
+
+	f := &helper.PreCondition{Client: client.Kubernetes}
+	f.MustHaveAdmissionRegistrationV1(t)
+
+	croConfig := operatorv1.PodResourceOverrideSpec{
+		LimitCPUToMemoryPercent:     200,
+		CPURequestToLimitPercent:    25,
+		MemoryRequestToLimitPercent: 50,
+	}
+	override := operatorv1.PodResourceOverride{
+		Spec: croConfig,
+	}
+
+	t.Logf("setting CRO webhook configuration - %s", croConfig.String())
+	current, changed := helper.EnsureAdmissionWebhook(t, client.Operator, "cluster", override, nil)
+	defer helper.RemoveAdmissionWebhook(t, client.Operator, current.GetName())
+
+	t.Log("waiting for CRO webhook to become available")
+	current = helper.Wait(t, client.Operator, "cluster", helper.GetAvailableConditionFunc(current, changed))
+
+	f.MustHaveClusterResourceOverrideAdmissionConfiguration(t)
+	t.Log("webhook configuration has been set successfully")
+
+	ns, nsDisposer := helper.NewNamespace(t, client.Kubernetes, "roe2e", true)
+	defer nsDisposer.Dispose()
+
+	roSpec := autoscalingv1.ResourceOverrideSpec{
+		PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+			LimitCPUToMemoryPercent:     100,
+			CPURequestToLimitPercent:    50,
+			MemoryRequestToLimitPercent: 75,
+		},
+	}
+	t.Log("creating ResourceOverride with different ratios than CRO")
+	_, roDisposer := helper.CreateResourceOverride(t, client.Operator, ns.GetName(), "test-ro", roSpec)
+	defer roDisposer.Dispose()
+
+	t.Log("waiting for ResourceOverride validation to pass")
+	helper.WaitForResourceOverrideCondition(t, client.Operator, ns.GetName(), "test-ro", helper.IsResourceOverrideValidationPassing)
+
+	t.Log("creating pod and verifying RO ratios take precedence over CRO")
+	requirements := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("1024Mi"),
+			corev1.ResourceCPU:    resource.MustParse("1000m"),
+		},
+	}
+
+	resourceWant := map[string]corev1.ResourceRequirements{
+		"test": {
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("1024Mi"),
+				corev1.ResourceCPU:    resource.MustParse("1000m"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("768Mi"),
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+			},
+		},
+	}
+
+	podGot, podDisposer := helper.NewPodWithResourceRequirement(t, client.Kubernetes, ns.GetName(), "test", requirements)
+	defer podDisposer.Dispose()
+
+	helper.MustMatchMemoryAndCPU(t, resourceWant, &podGot.Spec)
+}
+
+func TestResourceOverrideAdmissionWithPodSelector(t *testing.T) {
+	client := helper.NewClient(t, options.config)
+
+	f := &helper.PreCondition{Client: client.Kubernetes}
+	f.MustHaveAdmissionRegistrationV1(t)
+
+	croConfig := operatorv1.PodResourceOverrideSpec{
+		LimitCPUToMemoryPercent:     200,
+		CPURequestToLimitPercent:    25,
+		MemoryRequestToLimitPercent: 50,
+	}
+	override := operatorv1.PodResourceOverride{
+		Spec: croConfig,
+	}
+
+	t.Logf("setting CRO webhook configuration - %s", croConfig.String())
+	current, changed := helper.EnsureAdmissionWebhook(t, client.Operator, "cluster", override, nil)
+	defer helper.RemoveAdmissionWebhook(t, client.Operator, current.GetName())
+
+	t.Log("waiting for CRO webhook to become available")
+	current = helper.Wait(t, client.Operator, "cluster", helper.GetAvailableConditionFunc(current, changed))
+
+	f.MustHaveClusterResourceOverrideAdmissionConfiguration(t)
+	t.Log("webhook configuration has been set successfully")
+
+	ns, nsDisposer := helper.NewNamespace(t, client.Kubernetes, "roe2e", true)
+	defer nsDisposer.Dispose()
+
+	roSpec := autoscalingv1.ResourceOverrideSpec{
+		PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+			CPURequestToLimitPercent:    75,
+			MemoryRequestToLimitPercent: 90,
+		},
+		PodSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"override": "custom",
+			},
+		},
+	}
+	t.Log("creating ResourceOverride with podSelector")
+	_, roDisposer := helper.CreateResourceOverride(t, client.Operator, ns.GetName(), "test-ro-selector", roSpec)
+	defer roDisposer.Dispose()
+
+	t.Log("waiting for ResourceOverride validation to pass")
+	helper.WaitForResourceOverrideCondition(t, client.Operator, ns.GetName(), "test-ro-selector", helper.IsResourceOverrideValidationPassing)
+
+	requirements := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+			corev1.ResourceCPU:    resource.MustParse("1000m"),
+		},
+	}
+
+	t.Log("creating pod with matching label - expecting RO ratios")
+	resourceWantRO := map[string]corev1.ResourceRequirements{
+		"test": {
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+				corev1.ResourceCPU:    resource.MustParse("1000m"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("460Mi"),
+				corev1.ResourceCPU:    resource.MustParse("750m"),
+			},
+		},
+	}
+
+	podGot1, podDisposer1 := helper.NewPodWithLabels(t, client.Kubernetes, ns.GetName(), "test", requirements, map[string]string{"override": "custom"})
+	defer podDisposer1.Dispose()
+
+	helper.MustMatchMemoryAndCPU(t, resourceWantRO, &podGot1.Spec)
+
+	t.Log("creating pod without matching label - expecting CRO ratios")
+	resourceWantCRO := map[string]corev1.ResourceRequirements{
+		"test": {
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+				corev1.ResourceCPU:    resource.MustParse("1000m"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+				corev1.ResourceCPU:    resource.MustParse("250m"),
+			},
+		},
+	}
+
+	podGot2, podDisposer2 := helper.NewPodWithResourceRequirement(t, client.Kubernetes, ns.GetName(), "test", requirements)
+	defer podDisposer2.Dispose()
+
+	helper.MustMatchMemoryAndCPU(t, resourceWantCRO, &podGot2.Spec)
+}
+
+func TestResourceOverrideFallbackToCRO(t *testing.T) {
+	client := helper.NewClient(t, options.config)
+
+	f := &helper.PreCondition{Client: client.Kubernetes}
+	f.MustHaveAdmissionRegistrationV1(t)
+
+	croConfig := operatorv1.PodResourceOverrideSpec{
+		LimitCPUToMemoryPercent:     200,
+		CPURequestToLimitPercent:    25,
+		MemoryRequestToLimitPercent: 50,
+	}
+	override := operatorv1.PodResourceOverride{
+		Spec: croConfig,
+	}
+
+	t.Logf("setting CRO webhook configuration - %s", croConfig.String())
+	current, changed := helper.EnsureAdmissionWebhook(t, client.Operator, "cluster", override, nil)
+	defer helper.RemoveAdmissionWebhook(t, client.Operator, current.GetName())
+
+	t.Log("waiting for CRO webhook to become available")
+	current = helper.Wait(t, client.Operator, "cluster", helper.GetAvailableConditionFunc(current, changed))
+
+	f.MustHaveClusterResourceOverrideAdmissionConfiguration(t)
+	t.Log("webhook configuration has been set successfully")
+
+	ns, nsDisposer := helper.NewNamespace(t, client.Kubernetes, "roe2e", true)
+	defer nsDisposer.Dispose()
+
+	roSpec := autoscalingv1.ResourceOverrideSpec{
+		PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+			LimitCPUToMemoryPercent:     100,
+			CPURequestToLimitPercent:    50,
+			MemoryRequestToLimitPercent: 75,
+		},
+	}
+	t.Log("creating ResourceOverride with different ratios than CRO")
+	_, roDisposer := helper.CreateResourceOverride(t, client.Operator, ns.GetName(), "test-ro-fallback", roSpec)
+
+	t.Log("waiting for ResourceOverride validation to pass")
+	helper.WaitForResourceOverrideCondition(t, client.Operator, ns.GetName(), "test-ro-fallback", helper.IsResourceOverrideValidationPassing)
+
+	requirements := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("1024Mi"),
+			corev1.ResourceCPU:    resource.MustParse("1000m"),
+		},
+	}
+
+	t.Log("creating pod and verifying RO ratios are applied")
+	resourceWantRO := map[string]corev1.ResourceRequirements{
+		"test": {
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("1024Mi"),
+				corev1.ResourceCPU:    resource.MustParse("1000m"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("768Mi"),
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+			},
+		},
+	}
+
+	podGot1, podDisposer1 := helper.NewPodWithResourceRequirement(t, client.Kubernetes, ns.GetName(), "test", requirements)
+	defer podDisposer1.Dispose()
+
+	helper.MustMatchMemoryAndCPU(t, resourceWantRO, &podGot1.Spec)
+
+	t.Log("deleting ResourceOverride and verifying fallback to CRO ratios")
+	roDisposer.Dispose()
+
+	resourceWantCRO := map[string]corev1.ResourceRequirements{
+		"test": {
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("1024Mi"),
+				corev1.ResourceCPU:    resource.MustParse("2000m"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+			},
+		},
+	}
+
+	podGot2, podDisposer2 := helper.NewPodWithResourceRequirement(t, client.Kubernetes, ns.GetName(), "test", requirements)
+	defer podDisposer2.Dispose()
+
+	helper.MustMatchMemoryAndCPU(t, resourceWantCRO, &podGot2.Spec)
+}
+
+func TestResourceOverrideConfigurationChange(t *testing.T) {
+	client := helper.NewClient(t, options.config)
+
+	f := &helper.PreCondition{Client: client.Kubernetes}
+	f.MustHaveAdmissionRegistrationV1(t)
+
+	croConfig := operatorv1.PodResourceOverrideSpec{
+		LimitCPUToMemoryPercent:     200,
+		CPURequestToLimitPercent:    25,
+		MemoryRequestToLimitPercent: 50,
+	}
+	override := operatorv1.PodResourceOverride{
+		Spec: croConfig,
+	}
+
+	t.Logf("setting CRO webhook configuration - %s", croConfig.String())
+	current, changed := helper.EnsureAdmissionWebhook(t, client.Operator, "cluster", override, nil)
+	defer helper.RemoveAdmissionWebhook(t, client.Operator, current.GetName())
+
+	t.Log("waiting for CRO webhook to become available")
+	current = helper.Wait(t, client.Operator, "cluster", helper.GetAvailableConditionFunc(current, changed))
+
+	f.MustHaveClusterResourceOverrideAdmissionConfiguration(t)
+	t.Log("webhook configuration has been set successfully")
+
+	ns, nsDisposer := helper.NewNamespace(t, client.Kubernetes, "roe2e", true)
+	defer nsDisposer.Dispose()
+
+	roSpec := autoscalingv1.ResourceOverrideSpec{
+		PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+			LimitCPUToMemoryPercent:     100,
+			CPURequestToLimitPercent:    50,
+			MemoryRequestToLimitPercent: 50,
+		},
+	}
+	t.Log("creating ResourceOverride with initial ratios")
+	ro, roDisposer := helper.CreateResourceOverride(t, client.Operator, ns.GetName(), "test-ro-update", roSpec)
+	defer roDisposer.Dispose()
+
+	t.Log("waiting for ResourceOverride validation to pass")
+	ro = helper.WaitForResourceOverrideCondition(t, client.Operator, ns.GetName(), "test-ro-update", helper.IsResourceOverrideValidationPassing)
+
+	t.Log("creating pod and verifying initial RO ratios")
+	requirements := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("1024Mi"),
+			corev1.ResourceCPU:    resource.MustParse("1000m"),
+		},
+	}
+
+	resourceWantBefore := map[string]corev1.ResourceRequirements{
+		"test": {
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("1024Mi"),
+				corev1.ResourceCPU:    resource.MustParse("1000m"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+			},
+		},
+	}
+
+	podGot1, podDisposer1 := helper.NewPodWithResourceRequirement(t, client.Kubernetes, ns.GetName(), "test", requirements)
+	defer podDisposer1.Dispose()
+
+	helper.MustMatchMemoryAndCPU(t, resourceWantBefore, &podGot1.Spec)
+
+	t.Log("updating ResourceOverride to new ratios")
+	ro.Spec.PodResourceOverride.CPURequestToLimitPercent = 75
+	ro.Spec.PodResourceOverride.MemoryRequestToLimitPercent = 75
+	_, err := client.Operator.AutoscalingV1().ResourceOverrides(ns.GetName()).Update(context.TODO(), ro, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// TODO: watch for flakes since we can't guarantee the operand's informer has
+	// synced the updated spec before the pod creation below hits the webhook.
+	time.Sleep(2 * time.Second)
+
+	t.Log("creating pod and verifying updated RO ratios")
+	resourceWantAfter := map[string]corev1.ResourceRequirements{
+		"test": {
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("1024Mi"),
+				corev1.ResourceCPU:    resource.MustParse("1000m"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("768Mi"),
+				corev1.ResourceCPU:    resource.MustParse("750m"),
+			},
+		},
+	}
+
+	podGot2, podDisposer2 := helper.NewPodWithResourceRequirement(t, client.Kubernetes, ns.GetName(), "test", requirements)
+	defer podDisposer2.Dispose()
+
+	helper.MustMatchMemoryAndCPU(t, resourceWantAfter, &podGot2.Spec)
+}
+
+func TestResourceOverrideAdmissionWithCPURequestToRequestPercent(t *testing.T) {
+	client := helper.NewClient(t, options.config)
+
+	f := &helper.PreCondition{Client: client.Kubernetes}
+	f.MustHaveAdmissionRegistrationV1(t)
+
+	croConfig := operatorv1.PodResourceOverrideSpec{
+		MemoryRequestToLimitPercent: 50,
+	}
+	override := operatorv1.PodResourceOverride{
+		Spec: croConfig,
+	}
+
+	t.Logf("setting CRO webhook configuration - %s", croConfig.String())
+	current, changed := helper.EnsureAdmissionWebhook(t, client.Operator, "cluster", override, nil)
+	defer helper.RemoveAdmissionWebhook(t, client.Operator, current.GetName())
+
+	t.Log("waiting for CRO webhook to become available")
+	current = helper.Wait(t, client.Operator, "cluster", helper.GetAvailableConditionFunc(current, changed))
+
+	f.MustHaveClusterResourceOverrideAdmissionConfiguration(t)
+	t.Log("webhook configuration has been set successfully")
+
+	ns, nsDisposer := helper.NewNamespace(t, client.Kubernetes, "roe2e", true)
+	defer nsDisposer.Dispose()
+
+	roSpec := autoscalingv1.ResourceOverrideSpec{
+		PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+			CPURequestToRequestPercent:  50,
+			MemoryRequestToLimitPercent: 50,
+		},
+	}
+	t.Log("creating ResourceOverride with initial ratios")
+	_, roDisposer := helper.CreateResourceOverride(t, client.Operator, ns.GetName(), "test-ro-cpurequest", roSpec)
+	defer roDisposer.Dispose()
+
+	t.Log("waiting for ResourceOverride validation to pass")
+	helper.WaitForResourceOverrideCondition(t, client.Operator, ns.GetName(), "test-ro-cpurequest", helper.IsResourceOverrideValidationPassing)
+
+	t.Log("creating pod and verifying CPU request is scale")
+	requirements := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("200m"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+
+	resourceWant := map[string]corev1.ResourceRequirements{
+		"app": {
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+			},
+		},
+	}
+
+	podGot, podDisposer := helper.NewPodWithResourceRequirement(t, client.Kubernetes, ns.GetName(), "app", requirements)
+	defer podDisposer.Dispose()
 
 	helper.MustMatchMemoryAndCPU(t, resourceWant, &podGot.Spec)
 }

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -1,0 +1,227 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	autoscalingv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/autoscaling/v1"
+	"github.com/openshift/cluster-resource-override-admission-operator/test/helper"
+)
+
+// This file tests the operator alone
+
+func TestResourceOverrideValidSpec(t *testing.T) {
+	tests := []struct {
+		name       string
+		namespace  string
+		spec       autoscalingv1.ResourceOverrideSpec
+		wantStatus corev1.ConditionStatus
+		wantReason string
+	}{
+		{
+			name:      "test-resourceoverride-valid-spec",
+			namespace: "test-namespace",
+			spec: autoscalingv1.ResourceOverrideSpec{
+				PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+					MemoryRequestToLimitPercent: 50,
+					CPURequestToRequestPercent:  50,
+				},
+			},
+			wantStatus: corev1.ConditionFalse,
+			wantReason: "",
+		},
+		{
+			name:      "test-resourceoverride-valid-spec-with-podselector",
+			namespace: "test-namespace",
+			spec: autoscalingv1.ResourceOverrideSpec{
+				PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+					MemoryRequestToLimitPercent: 50,
+					CPURequestToRequestPercent:  50,
+				},
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": "test",
+					},
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "environment",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"production", "staging"},
+						},
+					},
+				},
+			},
+			wantStatus: corev1.ConditionFalse,
+			wantReason: "",
+		},
+		{
+			name:      "test-resourceoverride-exempt-namespace",
+			namespace: "openshift-monitoring",
+			spec: autoscalingv1.ResourceOverrideSpec{
+				PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+					MemoryRequestToLimitPercent: 50,
+					CPURequestToRequestPercent:  50,
+				},
+			},
+			wantStatus: corev1.ConditionTrue,
+			wantReason: autoscalingv1.ExemptNamespace,
+		},
+	}
+
+	client := helper.NewClient(t, options.config)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ns, nsDisposer := helper.NewNamespace(t, client.Kubernetes, test.namespace, false)
+			defer nsDisposer.Dispose()
+
+			_, roDisposer := helper.CreateResourceOverride(t, client.Operator, ns.Name, test.name, test.spec)
+			defer roDisposer.Dispose()
+
+			ro := helper.WaitForResourceOverrideCondition(t, client.Operator, ns.Name, test.name, func(override *autoscalingv1.ResourceOverride) bool {
+				condition := helper.GetResourceOverrideCondition(override, autoscalingv1.ValidationFailure)
+				return condition != nil
+			})
+
+			condition := helper.GetResourceOverrideCondition(ro, autoscalingv1.ValidationFailure)
+			require.Equal(t, test.wantStatus, condition.Status)
+			if test.wantReason != "" {
+				require.Equal(t, test.wantReason, condition.Reason)
+			}
+		})
+	}
+}
+
+func TestResourceOverrideInvalidCRDSpec(t *testing.T) {
+	tests := []struct {
+		name string
+		spec autoscalingv1.ResourceOverrideSpec
+	}{
+		{
+			name: "test-resourceoverride-invalid-override-values",
+			spec: autoscalingv1.ResourceOverrideSpec{
+				PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+					MemoryRequestToLimitPercent: 200,
+					CPURequestToLimitPercent:    -1,
+				},
+			},
+		},
+		{
+			name: "test-resourceoverride-invalid-podselector-operator",
+			spec: autoscalingv1.ResourceOverrideSpec{
+				PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+					MemoryRequestToLimitPercent: 50,
+				},
+				PodSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOperator("InvalidOperator"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	client := helper.NewClient(t, options.config)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ns, nsDisposer := helper.NewNamespace(t, client.Kubernetes, "test-namespace", false)
+			defer nsDisposer.Dispose()
+
+			request := &autoscalingv1.ResourceOverride{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      test.name,
+					Namespace: ns.Name,
+				},
+				Spec: test.spec,
+			}
+
+			_, err := client.Operator.AutoscalingV1().ResourceOverrides(ns.Name).Create(t.Context(), request, metav1.CreateOptions{})
+			require.True(t, k8serrors.IsInvalid(err), "expected CRD validation to reject invalid spec, got: %v", err)
+		})
+	}
+}
+
+func TestResourceOverrideInvalidReconcilerSpec(t *testing.T) {
+	tests := []struct {
+		name string
+		spec autoscalingv1.ResourceOverrideSpec
+	}{
+		{
+			name: "test-resourceoverride-in-empty-values",
+			spec: autoscalingv1.ResourceOverrideSpec{
+				PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+					MemoryRequestToLimitPercent: 50,
+				},
+				PodSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "test-resourceoverride-exists-with-values",
+			spec: autoscalingv1.ResourceOverrideSpec{
+				PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+					MemoryRequestToLimitPercent: 50,
+				},
+				PodSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOpExists,
+							Values:   []string{"foo"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "test-resourceoverride-invalid-matchlabels-key",
+			spec: autoscalingv1.ResourceOverrideSpec{
+				PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+					MemoryRequestToLimitPercent: 50,
+				},
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"invalid key": "value",
+					},
+				},
+			},
+		},
+	}
+
+	client := helper.NewClient(t, options.config)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ns, nsDisposer := helper.NewNamespace(t, client.Kubernetes, "test-namespace", false)
+			defer nsDisposer.Dispose()
+
+			_, roDisposer := helper.CreateResourceOverride(t, client.Operator, ns.Name, test.name, test.spec)
+			defer roDisposer.Dispose()
+
+			ro := helper.WaitForResourceOverrideCondition(t, client.Operator, ns.Name, test.name, func(override *autoscalingv1.ResourceOverride) bool {
+				condition := helper.GetResourceOverrideCondition(override, autoscalingv1.ValidationFailure)
+				return condition != nil
+			})
+
+			condition := helper.GetResourceOverrideCondition(ro, autoscalingv1.ValidationFailure)
+			require.Equal(t, corev1.ConditionTrue, condition.Status)
+			require.Equal(t, autoscalingv1.InvalidParameters, condition.Reason)
+		})
+	}
+}

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -97,6 +97,9 @@ func TestUpgradePost(t *testing.T) {
 	// Therefore, old operand pods get removed before new ones start and the webhook can be briefly unreachable, and flake the test.
 	helper.WaitForDeploymentRollout(t, client.Kubernetes, operatorNamespace, "clusterresourceoverride")
 
+	f := &helper.PreCondition{Client: client.Kubernetes}
+	f.MustHaveClusterResourceOverrideAdmissionConfiguration(t)
+
 	t.Log("verifying webhook still mutates pods after upgrade")
 	verifyAdmissionWebhook(t, client.Kubernetes)
 }

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	autoscalingv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/autoscaling/v1"
 	operatorv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/operator/v1"
 	"github.com/openshift/cluster-resource-override-admission-operator/pkg/generated/clientset/versioned"
 	"github.com/openshift/cluster-resource-override-admission-operator/pkg/tlsprofile"
@@ -41,6 +42,7 @@ func (d Disposer) Dispose() {
 }
 
 type ConditionFunc func(override *operatorv1.ClusterResourceOverride) bool
+type ResourceOverrideConditionFunc func(override *autoscalingv1.ResourceOverride) bool
 
 type Client struct {
 	Operator   versioned.Interface
@@ -205,6 +207,51 @@ func NewPodWithResourceRequirement(t *testing.T, client kubernetes.Interface, na
 	return
 }
 
+func NewPodWithLabels(t *testing.T, client kubernetes.Interface, namespace string, containerName string, requirements corev1.ResourceRequirements, labels map[string]string) (pod *corev1.Pod, disposer Disposer) {
+	request := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "croe2e-",
+			Labels:       labels,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  containerName,
+					Image: "openshift/hello-openshift",
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "app",
+							ContainerPort: 8080,
+						},
+					},
+					Resources: requirements,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: ptr.To(false),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
+						RunAsNonRoot: ptr.To(true),
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: "RuntimeDefault",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	object, err := client.CoreV1().Pods(namespace).Create(context.TODO(), request, metav1.CreateOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, object)
+
+	pod = object
+	disposer = func() {
+		err := client.CoreV1().Pods(object.Namespace).Delete(context.TODO(), object.Name, metav1.DeleteOptions{})
+		require.NoError(t, err)
+	}
+	return
+}
+
 func GetClusterResourceOverride(t *testing.T, client versioned.Interface, name string) *operatorv1.ClusterResourceOverride {
 	current, err := client.OperatorV1().ClusterResourceOverrides().Get(context.TODO(), name, metav1.GetOptions{})
 	require.NoError(t, err)
@@ -297,6 +344,65 @@ func IsAvailable(override *operatorv1.ClusterResourceOverride) bool {
 	}
 
 	return true
+}
+
+func GetResourceOverrideCondition(override *autoscalingv1.ResourceOverride, condType autoscalingv1.ResourceOverrideConditionType) *autoscalingv1.ResourceOverrideCondition {
+	for i := range override.Status.Conditions {
+		condition := &override.Status.Conditions[i]
+		if condition.Type == condType {
+			return condition
+		}
+	}
+
+	return nil
+}
+
+func IsResourceOverrideValidationPassing(override *autoscalingv1.ResourceOverride) bool {
+	condition := GetResourceOverrideCondition(override, autoscalingv1.ValidationFailure)
+	if condition == nil {
+		return false
+	}
+	return condition.Status == corev1.ConditionFalse
+}
+
+func WaitForResourceOverrideCondition(t *testing.T, client versioned.Interface, namespace, name string, f ResourceOverrideConditionFunc) (override *autoscalingv1.ResourceOverride) {
+	err := wait.PollUntilContextTimeout(t.Context(), WaitInterval, WaitTimeout, true, func(ctx context.Context) (done bool, err error) {
+		override, err = client.AutoscalingV1().ResourceOverrides(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+
+		if override == nil || !f(override) {
+			return false, nil
+		}
+
+		return true, nil
+	})
+
+	require.NoErrorf(t, err, "wait.Poll returned error - %v", err)
+	require.NotNil(t, override)
+	return
+}
+
+func CreateResourceOverride(t *testing.T, client versioned.Interface, namespace, name string, spec autoscalingv1.ResourceOverrideSpec) (ro *autoscalingv1.ResourceOverride, disposer Disposer) {
+	request := &autoscalingv1.ResourceOverride{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: spec,
+	}
+
+	object, err := client.AutoscalingV1().ResourceOverrides(namespace).Create(t.Context(), request, metav1.CreateOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, object)
+
+	ro = object
+	disposer = func() {
+		err := client.AutoscalingV1().ResourceOverrides(namespace).Delete(t.Context(), name, metav1.DeleteOptions{})
+		require.NoError(t, err)
+	}
+	return
 }
 
 func IsMatch(t *testing.T, requirementsWant, requirementsGot corev1.ResourceRequirements) {


### PR DESCRIPTION
Introduces a new controller to manage the new ResourceOverride objects.

Jira References:
- [AUTOSCALE-863](https://redhat.atlassian.net/browse/AUTOSCALE-863)
- [AUTOSCALE-864](https://redhat.atlassian.net/browse/AUTOSCALE-864)
- [AUTOSCALE-865](https://redhat.atlassian.net/browse/AUTOSCALE-865)
- [AUTOSCALE-866](https://redhat.atlassian.net/browse/AUTOSCALE-866)

_**BLOCKED:** Waiting for operand PR to merge so that the operator's e2e's pass_

---

**Controller:**
- New dedicated controller that watches ResourceOverride objects across all namespaces
- RO controller starts alongside the existing CRO controller, sharing the same client and shutdown context

**RBAC:**
- Webhook ClusterRole: added get/list/watch on resourceoverrides
- Two aggregated ClusterRoles for namespace users: admin/edit (full CRUD) and view (read-only)

**Tests:**
- Added unit tests for controller, reconciler, builder, and updater
- Added e2e tests for the operator alone and for the operator + operand
- Added test helpers for RO

**Bug fix:**
- Fixed nil-dereference bug in CRO condition builder's init(). Checks status.Conditions == nil instead of status == nil

**RO vs CRO code structure:**

Because the RO controller doesn't manage multiple resources like the CRO controller does, there are a few simplifications in code structure:
- Inline validation over handler chain: Currently only one reconciliation concern (validation) for RO, so a handler chain isn't necessary
- Combined builder.go and error.go: CRO splits these into two files, but the much simpler RO has no need to separate the files
- No enqueuer or secondary watches: RO doesn't manage infrastructure so it has no need for this

---

**Questions:**
- I made the reconciler emit a klog.V(4).Infof log for objects deleted during reconciliation instead of a klog.Errorf() like the CRO does. My assumption is that the CRO emits an Errorf() because it's a cluster wide singleton which shouldn't be deleted during reconciliation. Since RO's will be more routinely created/deleted, I thought a standard log for deleted RO's made more sense. Thoughts?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for `ResourceOverride` objects, including validation and status condition handling, pod-selector scoping with fallback to cluster defaults, and admission-driven ratio updates.
  - Expanded the operator to run the new `resourceoverride` control loop alongside the existing `clusterresourceoverride` loop.
- **Bug Fixes**
  - Corrected condition initialization behavior and clarified an aggregated RBAC role description.
- **Chores**
  - Updated stable deployment manifests and RBAC (including `events` create/patch) and added a `unit-test` make target.
- **Tests**
  - Expanded unit and end-to-end coverage for admission, reconciliation, and status behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->