### PR TITLE
OCPBUGS-99423: Update TLS Profile E2Es

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,10 +138,12 @@ unit-test:
 	$(GO) test -v -count=1 $(GO_TEST_PACKAGES)
 
 # run e2e test(s)
+E2E_SKIP ?=
+
 e2e:
 	$(KUBECTL) -n $(OPERATOR_NAMESPACE) rollout status -w deployment/clusterresourceoverride-operator
 	export GO111MODULE=on
-	$(GO) test -v -count=1 -timeout=15m ./test/e2e/... --kubeconfig=${KUBECONFIG} --namespace=$(OPERATOR_NAMESPACE)
+	$(GO) test -v -count=1 -timeout=15m ./test/e2e/... $(if $(E2E_SKIP),-skip '$(E2E_SKIP)') --kubeconfig=${KUBECONFIG} --namespace=$(OPERATOR_NAMESPACE)
 
 e2e-upgrade-pre:
 	$(GO) test -v -count=1 -timeout=10m ./test/e2e/... -run TestUpgradePre --kubeconfig=${KUBECONFIG} --namespace=$(OPERATOR_NAMESPACE)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -920,11 +919,7 @@ func TestResourceOverrideConfigurationChange(t *testing.T) {
 	_, err := client.Operator.AutoscalingV1().ResourceOverrides(ns.GetName()).Update(context.TODO(), ro, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
-	// TODO: watch for flakes since we can't guarantee the operand's informer has
-	// synced the updated spec before the pod creation below hits the webhook.
-	time.Sleep(2 * time.Second)
-
-	t.Log("creating pod and verifying updated RO ratios")
+	t.Log("creating pod and verifying updated RO ratios (retrying until informer syncs)")
 	resourceWantAfter := map[string]corev1.ResourceRequirements{
 		"test": {
 			Limits: corev1.ResourceList{
@@ -938,10 +933,8 @@ func TestResourceOverrideConfigurationChange(t *testing.T) {
 		},
 	}
 
-	podGot2, podDisposer2 := helper.NewPodWithResourceRequirement(t, client.Kubernetes, ns.GetName(), "test", requirements)
+	_, podDisposer2 := helper.EventuallyMustMatchPodMutation(t, client.Kubernetes, ns.GetName(), "test", requirements, resourceWantAfter)
 	defer podDisposer2.Dispose()
-
-	helper.MustMatchMemoryAndCPU(t, resourceWantAfter, &podGot2.Spec)
 }
 
 func TestResourceOverrideAdmissionWithCPURequestToRequestPercent(t *testing.T) {

--- a/test/e2e/tls_profile_test.go
+++ b/test/e2e/tls_profile_test.go
@@ -49,27 +49,41 @@ func ensureOperandDeployment(t *testing.T, client *helper.Client) {
 	_ = current
 }
 
+// saveAndRestoreTLSState saves the current APIServer TLS adherence policy and
+// profile, then registers a t.Cleanup to restore both and wait for cluster
+// operators to stabilize.
+func saveAndRestoreTLSState(t *testing.T) (initialProfile []byte) {
+	t.Helper()
+	initialAdherence := helper.GetAPIServerTLSAdherencePolicy(t, options.config)
+	initialProfile = helper.GetAPIServerTLSProfile(t, options.config)
+	t.Cleanup(func() {
+		adherence := initialAdherence
+		if adherence == "" {
+			adherence = string(configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly)
+		}
+		helper.SetAPIServerTLSAdherencePolicy(t, options.config, adherence)
+		helper.SetAPIServerTLSProfile(t, options.config, initialProfile)
+		helper.WaitForClusterOperatorsHealthy(t, options.config)
+	})
+	return
+}
+
 // TestOperandTLSProfileArgs verifies that the operand deployment's --tls-min-version
 // and --tls-cipher-suites args always match the cluster APIServer TLS profile across
 // three scenarios: initial config, a custom profile, and restoration of the original.
 // The test sets StrictAllComponents so that TLS profile changes are reflected in the operand.
 func TestOperandTLSProfileArgs(t *testing.T) {
+	if !helper.IsFeatureGateEnabled(t, options.config, "TLSAdherence") {
+		t.Skip("skipping: TLSAdherence feature gate is not enabled")
+	}
+
 	client := helper.NewClient(t, options.config)
 	ensureOperandDeployment(t, client)
 
-	// Save the initial APIServer TLS adherence policy and profile so we can restore them.
-	initialAdherence := helper.GetAPIServerTLSAdherencePolicy(t, options.config)
-	initialProfile := helper.GetAPIServerTLSProfile(t, options.config)
-	t.Cleanup(func() {
-		helper.SetAPIServerTLSAdherencePolicy(t, options.config, initialAdherence)
-		helper.SetAPIServerTLSProfile(t, options.config, initialProfile)
-	})
+	initialProfile := saveAndRestoreTLSState(t)
 
 	// Require StrictAllComponents so that TLS profile changes are reflected in the operand.
-	// Skip the test if the TLSAdherence feature gate is not available on this cluster.
-	if err := helper.TrySetAPIServerTLSAdherencePolicy(t, options.config, string(configv1.TLSAdherencePolicyStrictAllComponents)); err != nil {
-		t.Skipf("skipping: TLSAdherence feature gate not available on this cluster: %v", err)
-	}
+	helper.SetAPIServerTLSAdherencePolicy(t, options.config, string(configv1.TLSAdherencePolicyStrictAllComponents))
 
 	// Scenario 1: verify TLS args match the initial cluster configuration.
 	t.Log("scenario 1: verifying operand TLS args match initial cluster APIServer TLS profile")
@@ -91,40 +105,27 @@ func TestOperandTLSProfileArgs(t *testing.T) {
 // respond correctly to changes in the cluster APIServer TLSAdherence policy.
 // Requires the TLSAdherence feature gate to be enabled; skips otherwise.
 func TestOperandTLSAdherencePolicy(t *testing.T) {
+	if !helper.IsFeatureGateEnabled(t, options.config, "TLSAdherence") {
+		t.Skip("skipping: TLSAdherence feature gate is not enabled")
+	}
+
 	client := helper.NewClient(t, options.config)
 	ensureOperandDeployment(t, client)
 
-	// Save the initial state and restore on cleanup.
-	initialAdherence := helper.GetAPIServerTLSAdherencePolicy(t, options.config)
-	initialProfile := helper.GetAPIServerTLSProfile(t, options.config)
-	t.Cleanup(func() {
-		helper.SetAPIServerTLSAdherencePolicy(t, options.config, initialAdherence)
-		helper.SetAPIServerTLSProfile(t, options.config, initialProfile)
-	})
+	saveAndRestoreTLSState(t)
 
 	// Set a known TLS profile for the duration of this test so we can verify
 	// that the operand picks it up when StrictAllComponents is active.
 	customProfile := []byte(`{"type":"Custom","custom":{"ciphers":["ECDHE-ECDSA-CHACHA20-POLY1305","ECDHE-ECDSA-AES128-GCM-SHA256"]}}`)
 	helper.SetAPIServerTLSProfile(t, options.config, customProfile)
 
-	// Scenario A: NoOpinion (field cleared) — operand should use its own defaults (no TLS flags).
-	// This should also succeed if the feature gate is off (though possibly with a warning about a missing field)
-	t.Log("scenario A: NoOpinion — operand should use its own defaults")
-	helper.SetAPIServerTLSAdherencePolicy(t, options.config, "")
-	verifyOperandTLSArgs(t, client, options.config)
-
-	// Scenarios B and C require the TLSAdherence feature gate.
-	if !helper.IsFeatureGateEnabled(t, options.config, "TLSAdherence") {
-		t.Skip("skipping scenarios B and C: TLSAdherence feature gate is not enabled")
-	}
-
-	// Scenario B: LegacyAdheringComponentsOnly — operand should use its own defaults (no TLS flags).
-	t.Log("scenario B: LegacyAdheringComponentsOnly — operand should use its own defaults")
+	// Scenario A: LegacyAdheringComponentsOnly — operand should use its own defaults (no TLS flags).
+	t.Log("scenario A: LegacyAdheringComponentsOnly — operand should use its own defaults")
 	helper.SetAPIServerTLSAdherencePolicy(t, options.config, string(configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly))
 	verifyOperandTLSArgs(t, client, options.config)
 
-	// Scenario C: StrictAllComponents — operand must apply the cluster TLS profile.
-	t.Log("scenario C: StrictAllComponents — operand should apply cluster TLS profile")
+	// Scenario B: StrictAllComponents — operand must apply the cluster TLS profile.
+	t.Log("scenario B: StrictAllComponents — operand should apply cluster TLS profile")
 	helper.SetAPIServerTLSAdherencePolicy(t, options.config, string(configv1.TLSAdherencePolicyStrictAllComponents))
 	verifyOperandTLSArgs(t, client, options.config)
 }

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -5,46 +5,37 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/client-go/kubernetes"
 
 	operatorv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/operator/v1"
 	"github.com/openshift/cluster-resource-override-admission-operator/test/helper"
 )
 
-// verifyAdmissionWebhook creates an opt-in namespace and a pod with known
-// resource limits, then asserts that the CRO webhook mutated the pod's
-// resources according to the default CR config (50/25/200).
-func verifyAdmissionWebhook(t *testing.T, kubeClient kubernetes.Interface) {
-	t.Helper()
+// upgradeTestRequirements are the resource limits injected into test pods.
+// The CR config (50/25/200) mutates these to upgradeTestExpected.
+var upgradeTestRequirements = corev1.ResourceRequirements{
+	Limits: corev1.ResourceList{
+		corev1.ResourceMemory: resource.MustParse("512Mi"),
+		corev1.ResourceCPU:    resource.MustParse("2000m"),
+	},
+}
 
-	ns, nsDisposer := helper.NewNamespace(t, kubeClient, "upgrade-verify", true)
-	defer nsDisposer.Dispose()
-
-	requirements := corev1.ResourceRequirements{
+// upgradeTestExpected is what the webhook should produce given
+// upgradeTestRequirements and the CR config (50/25/200):
+//
+//	limitCPUToMemoryPercent=200  -> CPU limit  = 200% * 0.5Gi = 1000m
+//	memoryRequestToLimitPercent=50 -> memory request = 256Mi
+//	cpuRequestToLimitPercent=25    -> CPU request    = 250m
+var upgradeTestExpected = map[string]corev1.ResourceRequirements{
+	"test": {
 		Limits: corev1.ResourceList{
 			corev1.ResourceMemory: resource.MustParse("512Mi"),
-			corev1.ResourceCPU:    resource.MustParse("2000m"),
+			corev1.ResourceCPU:    resource.MustParse("1000m"),
 		},
-	}
-	pod, podDisposer := helper.NewPodWithResourceRequirement(t, kubeClient, ns.Name, "test", requirements)
-	defer podDisposer.Dispose()
-
-	// limitCPUToMemoryPercent=200 -> CPU limit = 200% * 0.5Gi = 1000m
-	// memoryRequestToLimitPercent=50 -> memory request = 256Mi
-	// cpuRequestToLimitPercent=25 -> CPU request = 250m
-	resourceWant := map[string]corev1.ResourceRequirements{
-		"test": {
-			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("512Mi"),
-				corev1.ResourceCPU:    resource.MustParse("1000m"),
-			},
-			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("256Mi"),
-				corev1.ResourceCPU:    resource.MustParse("250m"),
-			},
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+			corev1.ResourceCPU:    resource.MustParse("250m"),
 		},
-	}
-	helper.MustMatchMemoryAndCPU(t, resourceWant, &pod.Spec)
+	},
 }
 
 // TestUpgradePre creates the ClusterResourceOverride CR against the old
@@ -74,8 +65,12 @@ func TestUpgradePre(t *testing.T) {
 	f := &helper.PreCondition{Client: client.Kubernetes}
 	f.MustHaveClusterResourceOverrideAdmissionConfiguration(t)
 
+	ns, nsDisposer := helper.NewNamespace(t, client.Kubernetes, "upgrade-verify", true)
+	defer nsDisposer.Dispose()
+
 	t.Log("verifying webhook mutates pods correctly")
-	verifyAdmissionWebhook(t, client.Kubernetes)
+	_, podDisposer := helper.EventuallyMustMatchPodMutation(t, client.Kubernetes, ns.Name, "test", upgradeTestRequirements, upgradeTestExpected)
+	defer podDisposer.Dispose()
 }
 
 // TestUpgradePost validates that a pre-existing ClusterResourceOverride CR
@@ -100,6 +95,10 @@ func TestUpgradePost(t *testing.T) {
 	f := &helper.PreCondition{Client: client.Kubernetes}
 	f.MustHaveClusterResourceOverrideAdmissionConfiguration(t)
 
+	ns, nsDisposer := helper.NewNamespace(t, client.Kubernetes, "upgrade-verify", true)
+	defer nsDisposer.Dispose()
+
 	t.Log("verifying webhook still mutates pods after upgrade")
-	verifyAdmissionWebhook(t, client.Kubernetes)
+	_, podDisposer := helper.EventuallyMustMatchPodMutation(t, client.Kubernetes, ns.Name, "test", upgradeTestRequirements, upgradeTestExpected)
+	defer podDisposer.Dispose()
 }

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -460,6 +460,85 @@ func MustMatchMemoryAndCPU(t *testing.T, resourceWant map[string]corev1.Resource
 	}
 }
 
+func matchesMemoryAndCPU(resourceWant map[string]corev1.ResourceRequirements, specGot *corev1.PodSpec) bool {
+	for name, want := range resourceWant {
+		var got corev1.ResourceRequirements
+		found := false
+		for i, c := range specGot.Containers {
+			if c.Name == name {
+				got = specGot.Containers[i].Resources
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+		for _, res := range []corev1.ResourceName{corev1.ResourceMemory, corev1.ResourceCPU} {
+			if wantQ, ok := want.Requests[res]; ok {
+				if gotQ, ok := got.Requests[res]; !ok || !wantQ.Equal(gotQ) {
+					return false
+				}
+			}
+			if wantQ, ok := want.Limits[res]; ok {
+				if gotQ, ok := got.Limits[res]; !ok || !wantQ.Equal(gotQ) {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+// EventuallyMustMatchPodMutation polls by creating throwaway pods until one's
+// resources match the expected values, then returns that pod and a disposer.
+// Use this instead of a sleep when the webhook config may not have propagated yet.
+func EventuallyMustMatchPodMutation(t *testing.T, client kubernetes.Interface, namespace, containerName string, requirements corev1.ResourceRequirements, want map[string]corev1.ResourceRequirements) (pod *corev1.Pod, disposer Disposer) {
+	t.Helper()
+
+	err := wait.PollUntilContextTimeout(t.Context(), 10*time.Second, WaitTimeout, true, func(ctx context.Context) (bool, error) {
+		p, err := client.CoreV1().Pods(namespace).Create(ctx, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "croe2e-"},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:      containerName,
+					Image:     "openshift/hello-openshift",
+					Resources: requirements,
+					Ports:     []corev1.ContainerPort{{Name: "app", ContainerPort: 8080}},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: ptr.To(false),
+						Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+						RunAsNonRoot:             ptr.To(true),
+						SeccompProfile:           &corev1.SeccompProfile{Type: "RuntimeDefault"},
+					},
+				}},
+			},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			t.Logf("retrying: failed to create probe pod: %v", err)
+			return false, nil
+		}
+
+		if matchesMemoryAndCPU(want, &p.Spec) {
+			pod = p
+			return true, nil
+		}
+
+		t.Logf("pod mutation not yet matching expected values, retrying")
+		if err := client.CoreV1().Pods(namespace).Delete(t.Context(), p.Name, metav1.DeleteOptions{}); err != nil {
+			t.Logf("warning: failed to delete probe pod %s: %v", p.Name, err)
+		}
+		return false, nil
+	})
+
+	require.NoError(t, err, "timed out waiting for pod mutation to match expected values")
+	disposer = func() {
+		err := client.CoreV1().Pods(namespace).Delete(t.Context(), pod.Name, metav1.DeleteOptions{})
+		require.NoError(t, err)
+	}
+	return
+}
+
 func NewLimitRanges(t *testing.T, client kubernetes.Interface, namespace string, spec corev1.LimitRangeSpec) (object *corev1.LimitRange, disposer Disposer) {
 	request := corev1.LimitRange{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -512,6 +512,12 @@ var apiServerGVR = schema.GroupVersionResource{
 	Resource: "apiservers",
 }
 
+var clusterOperatorGVR = schema.GroupVersionResource{
+	Group:    "config.openshift.io",
+	Version:  "v1",
+	Resource: "clusteroperators",
+}
+
 // GetAPIServerTLSProfile returns the raw JSON bytes of the current
 // spec.tlsSecurityProfile field of the cluster APIServer object, or nil if
 // the field is not set.
@@ -715,4 +721,67 @@ func operandTLSArgsMatch(args []string, want tlsprofile.Args) bool {
 		}
 	}
 	return gotMinVersion == want.MinVersion && gotCipherSuites == want.CipherSuites
+}
+
+// WaitForClusterOperatorsHealthy waits for all cluster operators to report
+// Available=True, Progressing=False, Degraded=False. Logs a warning instead
+// of failing the test if the timeout is reached, since this is a best-effort
+// stabilization step after disruptive operations like TLS profile changes.
+func WaitForClusterOperatorsHealthy(t *testing.T, config *rest.Config) {
+	t.Helper()
+
+	dynClient, err := dynamic.NewForConfig(config)
+	require.NoError(t, err)
+
+	t.Log("waiting for all cluster operators to be healthy (Available=True, Progressing=False, Degraded=False)")
+
+	err = wait.PollUntilContextTimeout(t.Context(), 30*time.Second, 30*time.Minute, true, func(ctx context.Context) (bool, error) {
+		coList, err := dynClient.Resource(clusterOperatorGVR).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			t.Logf("transient error listing cluster operators: %v", err)
+			return false, nil
+		}
+
+		for _, co := range coList.Items {
+			conditions, found, err := unstructured.NestedSlice(co.Object, "status", "conditions")
+			if err != nil || !found {
+				t.Logf("cluster operator %s: no conditions found", co.GetName())
+				return false, nil
+			}
+
+			available := "False"
+			progressing := "True"
+			degraded := "True"
+
+			for _, c := range conditions {
+				cond, ok := c.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				condType, _, _ := unstructured.NestedString(cond, "type")
+				condStatus, _, _ := unstructured.NestedString(cond, "status")
+
+				switch condType {
+				case "Available":
+					available = condStatus
+				case "Progressing":
+					progressing = condStatus
+				case "Degraded":
+					degraded = condStatus
+				}
+			}
+
+			if available != "True" || progressing != "False" || degraded != "False" {
+				t.Logf("cluster operator %s not healthy: Available=%v Progressing=%v Degraded=%v",
+					co.GetName(), available, progressing, degraded)
+				return false, nil
+			}
+		}
+
+		return true, nil
+	})
+
+	if err != nil {
+		t.Logf("WARNING: timed out waiting for cluster operators to be healthy: %v", err)
+	}
 }


### PR DESCRIPTION
This PR applies the lessons learned while adding TLS adherence tests to CAO in https://github.com/openshift/cluster-api-actuator-pkg/pull/487
- Skip tests if the feature gate is off
- Don't try to remove the TLS adherence field once set since it's not allowed
- Try to get the cluster back to a healthy state at the end of the test

Additional changes:
- Provide an easy way to skip E2E test suites via the `Makefile` var `E2E_SKIP`
- Refactor possibly race-laden tests to keep trying a pod mutation while the mutating webhook config is taking effect in the API server. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests
- Improved TLS adherence and profile test coverage, including disabled-feature scenarios.
- Added reliable validation of pod resource updates and asynchronous configuration changes.
- Strengthened upgrade-test isolation, cleanup, and webhook mutation verification.
- Added checks that cluster operators return to a healthy state after testing.
- Improved test resilience by retrying until expected changes are observed.

## Chores
- Added an option to skip selected end-to-end tests during test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->