### PR TITLE
OCPBUGS-100330: Allow operator to run on control-plane nodes

### DIFF
--- a/artifacts/deploy/300_deployment.yaml
+++ b/artifacts/deploy/300_deployment.yaml
@@ -60,3 +60,10 @@ spec:
             capabilities:
               drop:
               - ALL
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists

--- a/bundle/manifests/clusterresourceoverride-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterresourceoverride-operator.clusterserviceversion.yaml
@@ -289,6 +289,13 @@ spec:
                 seccompProfile:
                   type: RuntimeDefault
               serviceAccountName: clusterresourceoverride-operator
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/master
+                operator: Exists
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/control-plane
+                operator: Exists
       permissions:
       - rules:
         - apiGroups:

--- a/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
+++ b/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
@@ -341,6 +341,13 @@ spec:
                   runAsNonRoot: true
                   seccompProfile:
                     type: RuntimeDefault
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/master
+                  operator: Exists
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/control-plane
+                  operator: Exists
   installModes:
     - supported: true
       type: OwnNamespace


### PR DESCRIPTION
This is to smooth out upgrades to 5.x which try to run the operator on control-plane nodes, but 4.22 operators don't have tolerations to run on masters, so they can't schedule.