### PR TITLE
OCPBUGS-100274: Replace hardcoded namespace with configurable OPERATOR_NAMESPACE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ IMAGE_VERSION := 5.0
 # this is the image tag of your custom dev image
 IMAGE_TAG := dev
 
-OPERATOR_NAMESPACE := openshift-cluster-resource-override
+OPERATOR_NAMESPACE ?= openshift-cluster-resource-override
+export OPERATOR_NAMESPACE
 OPERATOR_DEPLOYMENT_NAME 	:= clusterresourceoverride-operator
 
 export OLD_OPERATOR_IMAGE_URL_IN_CSV 	= quay.io/openshift/clusterresourceoverride-rhel8-operator:$(IMAGE_VERSION)
@@ -117,6 +118,9 @@ deploy:
 	cp manifests/stable/resourceoverride.crd.yaml $(KUBE_MANIFESTS_DIR)/
 	cp manifests/stable/resourceoverride-rbac.yaml $(KUBE_MANIFESTS_DIR)/
 	cp $(ARTIFACTS)/registry-env.yaml $(KUBE_MANIFESTS_DIR)/
+
+	# Inject the operator namespace into all copied manifests
+	find $(KUBE_MANIFESTS_DIR) -name "*.yaml" | xargs sed -i "s/openshift-cluster-resource-override/$(OPERATOR_NAMESPACE)/g"
 
 	$(REGISTRY_SETUP_BINARY) --mode=$(DEPLOY_MODE) --olm=false --configmap=$(CONFIGMAP_ENV_FILE)
 	./hack/update-image-url.sh "$(CONFIGMAP_ENV_FILE)" "$(DEPLOYMENT_YAML)"

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,29 @@ IMAGE_VERSION := 5.0
 # this is the image tag of your custom dev image
 IMAGE_TAG := dev
 
+OPERATOR_NAMESPACE ?= openshift-cluster-resource-override
+# Normalize: if the caller explicitly passed an empty string, fall back to the default.
+ifeq ($(strip $(OPERATOR_NAMESPACE)),)
 OPERATOR_NAMESPACE := openshift-cluster-resource-override
+endif
+
+_ns_tmpf := $(shell mktemp)
+_ns_check := $(shell \
+  printf '%s' $(OPERATOR_NAMESPACE) > $(_ns_tmpf); \
+  linecount=$$(wc -l < $(_ns_tmpf) | tr -d ' '); \
+  if [ "$$linecount" -ne 0 ]; then \
+    echo bad; \
+  else \
+    awk '{n=length($$0); if(n<1||n>63)exit; if($$0!~/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$$/){exit}; print "ok"}' $(_ns_tmpf); \
+  fi; \
+  rm -f $(_ns_tmpf))
+ifneq ($(_ns_check),ok)
+$(error OPERATOR_NAMESPACE "$(OPERATOR_NAMESPACE)" is not a valid Kubernetes namespace name. \
+  Must be lowercase alphanumeric and hyphens only, 1-63 characters, \
+  starting and ending with an alphanumeric character.)
+endif
+
+export OPERATOR_NAMESPACE
 OPERATOR_DEPLOYMENT_NAME 	:= clusterresourceoverride-operator
 
 export OLD_OPERATOR_IMAGE_URL_IN_CSV 	= quay.io/openshift/clusterresourceoverride-rhel8-operator:$(IMAGE_VERSION)
@@ -117,6 +139,9 @@ deploy:
 	cp manifests/stable/resourceoverride.crd.yaml $(KUBE_MANIFESTS_DIR)/
 	cp manifests/stable/resourceoverride-rbac.yaml $(KUBE_MANIFESTS_DIR)/
 	cp $(ARTIFACTS)/registry-env.yaml $(KUBE_MANIFESTS_DIR)/
+
+	# Inject the operator namespace into all copied manifests
+	find $(KUBE_MANIFESTS_DIR) -name "*.yaml" | xargs sed -i "s/openshift-cluster-resource-override/$(OPERATOR_NAMESPACE)/g"
 
 	$(REGISTRY_SETUP_BINARY) --mode=$(DEPLOY_MODE) --olm=false --configmap=$(CONFIGMAP_ENV_FILE)
 	./hack/update-image-url.sh "$(CONFIGMAP_ENV_FILE)" "$(DEPLOYMENT_YAML)"

--- a/hack/upgrade-test.sh
+++ b/hack/upgrade-test.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 : "${NEW_BUNDLE:?NEW_BUNDLE must be set}"
 : "${KUBECONFIG:?KUBECONFIG must be set}"
 
-NAMESPACE=openshift-cluster-resource-override
+NAMESPACE="${OPERATOR_NAMESPACE:-openshift-cluster-resource-override}"
 
 cleanup() {
     if [[ "${SKIP_CLEANUP:-}" == "true" ]]; then

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -17,9 +17,13 @@ import (
 )
 
 const (
-	operatorNamespace = "openshift-cluster-resource-override"
-	configMapName     = "clusterresourceoverride-configuration"
+	configMapName = "clusterresourceoverride-configuration"
 )
+
+// operatorNamespace is set from the --namespace flag (or OPERATOR_NAMESPACE env var as
+// a fallback) in TestMain. Tests that reference the operator namespace use this variable
+// so that running `OPERATOR_NAMESPACE=my-ns make e2e` works end-to-end.
+var operatorNamespace string
 
 func TestClusterResourceOverrideAdmissionWithOptIn(t *testing.T) {
 	tests := []struct {

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -2,14 +2,19 @@ package e2e
 
 import (
 	"flag"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-var namespace = flag.String("namespace", "", "namespace where tests will run")
+const defaultOperatorNamespace = "openshift-cluster-resource-override"
+
+var namespace = flag.String("namespace", "", "namespace where the operator is deployed; takes precedence over the OPERATOR_NAMESPACE env var")
 
 func init() {
 	// Some imported packages (e.g. controller-runtime) register a "kubeconfig"
@@ -37,9 +42,37 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
+	// Resolve the operator namespace with the following precedence (highest first):
+	//   1. --namespace CLI flag  (always passed by 'make e2e' as --namespace=$(OPERATOR_NAMESPACE))
+	//   2. OPERATOR_NAMESPACE environment variable  (used when running the test binary directly)
+	//   3. built-in default (openshift-cluster-resource-override)
+	ns := *namespace
+	if ns == "" {
+		ns = os.Getenv("OPERATOR_NAMESPACE")
+	}
+	if ns == "" {
+		ns = defaultOperatorNamespace
+	}
+
+	// Validate at the trust boundary before the value reaches any Kubernetes
+	// API call or is assigned to shared test state. Use the same IsDNS1123Label
+	// function Kubernetes itself uses to validate namespace names — this ensures
+	// our check stays in sync with Kubernetes validation rules automatically.
+	if errs := validation.IsDNS1123Label(ns); len(errs) > 0 {
+		panic(fmt.Sprintf(
+			"invalid operator namespace %q: %s",
+			ns, strings.Join(errs, "; "),
+		))
+	}
+
+	// Expose the resolved namespace through both options.namespace (used by
+	// TestDynamicClient) and the package-level operatorNamespace variable (used
+	// by every other test that references the operator deployment directly).
+	operatorNamespace = ns
+
 	options = &Options{
 		config:    config,
-		namespace: *namespace,
+		namespace: ns,
 	}
 
 	// run tests

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -9,7 +9,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-var namespace = flag.String("namespace", "", "namespace where tests will run")
+const defaultOperatorNamespace = "openshift-cluster-resource-override"
+
+var namespace = flag.String("namespace", "", "namespace where the operator is deployed; takes precedence over the OPERATOR_NAMESPACE env var")
 
 func init() {
 	// Some imported packages (e.g. controller-runtime) register a "kubeconfig"
@@ -37,9 +39,26 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
+	// Resolve the operator namespace with the following precedence (highest first):
+	//   1. --namespace CLI flag  (always passed by 'make e2e' as --namespace=$(OPERATOR_NAMESPACE))
+	//   2. OPERATOR_NAMESPACE environment variable  (used when running the test binary directly)
+	//   3. built-in default (openshift-cluster-resource-override)
+	ns := *namespace
+	if ns == "" {
+		ns = os.Getenv("OPERATOR_NAMESPACE")
+	}
+	if ns == "" {
+		ns = defaultOperatorNamespace
+	}
+
+	// Expose the resolved namespace through both options.namespace (used by
+	// TestDynamicClient) and the package-level operatorNamespace variable (used
+	// by every other test that references the operator deployment directly).
+	operatorNamespace = ns
+
 	options = &Options{
 		config:    config,
-		namespace: *namespace,
+		namespace: ns,
 	}
 
 	// run tests


### PR DESCRIPTION
Running `OPERATOR_NAMESPACE=clusterresourceoverride-operator make e2e` fails immediately with:
`kubectl -n openshift-cluster-resource-override rollout status -w deployment/clusterresourceoverride-operator                                                                                                   
Error from server (NotFound): namespaces "openshift-cluster-resource-override" not found                                                                                                                       
make: *** [Makefile:136: e2e] Error 1`

With this PR changes, if the user provides `OPERATOR_NAMESPACE` that value is picked up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure the operator namespace through a command-line option or environment variable.
  * Deployment manifests automatically use the selected namespace.
  * End-to-end and upgrade tests consistently use the configured namespace, with a default fallback.

* **Bug Fixes**
  * Custom namespace values are validated against Kubernetes naming requirements.
  * Empty namespace settings safely fall back to the default.
  * Deployment and upgrade testing now remain consistent when using custom namespaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->