### PR TITLE
OCPBUGS-99197: Add networking.k8s.io/networkpolicies RBAC to CSV

### DIFF
--- a/artifacts/deploy/200_rbac.yaml
+++ b/artifacts/deploy/200_rbac.yaml
@@ -230,6 +230,15 @@ rules:
     - list
     - watch
     - delete
+
+  - apiGroups:
+    - networking.k8s.io
+    resources:
+    - networkpolicies
+    verbs:
+    - create
+    - delete
+    - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/bundle/manifests/clusterresourceoverride-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterresourceoverride-operator.clusterserviceversion.yaml
@@ -44,7 +44,7 @@ metadata:
     categories: OpenShift Optional
     certifiedLevel: Primed
     containerImage: quay.io/openshift/clusterresourceoverride-rhel8-operator:5.0
-    createdAt: "2026-07-30T21:02:32Z"
+    createdAt: "2026-08-04T04:27:45Z"
     description: An operator to manage the OpenShift ClusterResourceOverride Mutating
       Admission Webhook Server
     features.operators.openshift.io/disconnected: "true"
@@ -431,6 +431,14 @@ spec:
           - list
           - watch
           - delete
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - update
         serviceAccountName: clusterresourceoverride-operator
     strategy: deployment
   installModes:

--- a/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
+++ b/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
@@ -221,6 +221,14 @@ spec:
             - list
             - watch
             - delete
+        - apiGroups:
+            - networking.k8s.io
+          resources:
+            - networkpolicies
+          verbs:
+            - create
+            - delete
+            - update
         serviceAccountName: clusterresourceoverride-operator
       clusterPermissions:
       - rules:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-99197

Add missing RBAC permissions for `networking.k8s.io/networkpolicies` to pass the `olm.required_network_policy_rbac_for_operands` Conforma policy check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The operator can now create, update, and delete Kubernetes network policies.

* **Chores**
  * Updated deployment metadata and permissions to support network policy management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->