### PR TITLE
OCPBUGS-104560: Reject ResourceOverride creation in exempt namespaces at admissi…

### DIFF
--- a/artifacts/deploy/200_rbac.yaml
+++ b/artifacts/deploy/200_rbac.yaml
@@ -110,6 +110,21 @@ rules:
     - list
     - watch
 
+  # to have the power to manage ValidatingAdmissionPolicy resources
+  - apiGroups:
+    - admissionregistration.k8s.io
+    resources:
+    - validatingadmissionpolicies
+    - validatingadmissionpolicybindings
+    verbs:
+    - create
+    - update
+    - patch
+    - delete
+    - get
+    - list
+    - watch
+
   # to grant power to the operand to watch Namespace(s) and LimitRange(s)
   - apiGroups:
     - ""

--- a/bundle/manifests/clusterresourceoverride-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/clusterresourceoverride-operator.clusterserviceversion.yaml
@@ -44,7 +44,7 @@ metadata:
     categories: OpenShift Optional
     certifiedLevel: Primed
     containerImage: quay.io/openshift/clusterresourceoverride-rhel8-operator:5.0
-    createdAt: "2026-08-04T04:27:45Z"
+    createdAt: "2026-08-05T20:19:10Z"
     description: An operator to manage the OpenShift ClusterResourceOverride Mutating
       Admission Webhook Server
     features.operators.openshift.io/disconnected: "true"
@@ -261,6 +261,19 @@ spec:
           - validatingwebhookconfigurations
           - mutatingwebhookconfigurations
           verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingadmissionpolicies
+          - validatingadmissionpolicybindings
+          verbs:
+          - create
+          - update
+          - patch
+          - delete
           - get
           - list
           - watch

--- a/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
+++ b/manifests/stable/clusterresourceoverride-operator.clusterserviceversion.yaml
@@ -347,6 +347,21 @@ spec:
             - list
             - watch
 
+        # to have the power to manage ValidatingAdmissionPolicy resources
+        - apiGroups:
+            - admissionregistration.k8s.io
+          resources:
+            - validatingadmissionpolicies
+            - validatingadmissionpolicybindings
+          verbs:
+            - create
+            - update
+            - patch
+            - delete
+            - get
+            - list
+            - watch
+
         # to grant power to the operand to watch Namespace(s) and LimitRange(s)
         - apiGroups:
             - ""

--- a/pkg/apis/operator/v1/override_types.go
+++ b/pkg/apis/operator/v1/override_types.go
@@ -99,6 +99,14 @@ type ClusterResourceOverrideResources struct {
 	// APiServiceRef points to the APIService object related to the ClusterResourceOverride
 	// admission webhook server.
 	MutatingWebhookConfigurationRef *corev1.ObjectReference `json:"mutatingWebhookConfigurationRef,omitempty"`
+
+	// ValidatingAdmissionPolicyRef points to the ValidatingAdmissionPolicy that
+	// prevents ResourceOverride objects from being created in exempt namespaces.
+	ValidatingAdmissionPolicyRef *corev1.ObjectReference `json:"validatingAdmissionPolicyRef,omitempty"`
+
+	// ValidatingAdmissionPolicyBindingRef points to the ValidatingAdmissionPolicyBinding
+	// that activates the exempt namespace policy.
+	ValidatingAdmissionPolicyBindingRef *corev1.ObjectReference `json:"validatingAdmissionPolicyBindingRef,omitempty"`
 }
 
 // PodResourceOverride is the configuration for the admission controller which

--- a/pkg/apis/operator/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1/zz_generated.deepcopy.go
@@ -148,6 +148,16 @@ func (in *ClusterResourceOverrideResources) DeepCopyInto(out *ClusterResourceOve
 		*out = new(corev1.ObjectReference)
 		**out = **in
 	}
+	if in.ValidatingAdmissionPolicyRef != nil {
+		in, out := &in.ValidatingAdmissionPolicyRef, &out.ValidatingAdmissionPolicyRef
+		*out = new(corev1.ObjectReference)
+		**out = **in
+	}
+	if in.ValidatingAdmissionPolicyBindingRef != nil {
+		in, out := &in.ValidatingAdmissionPolicyBindingRef, &out.ValidatingAdmissionPolicyBindingRef
+		*out = new(corev1.ObjectReference)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/asset/validatingadmissionpolicy.go
+++ b/pkg/asset/validatingadmissionpolicy.go
@@ -1,0 +1,100 @@
+package asset
+
+import (
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	validatingAdmissionPolicyName = "resourceoverride-exempt-namespace"
+)
+
+func (a *Asset) NewValidatingAdmissionPolicy() *validatingAdmissionPolicy {
+	return &validatingAdmissionPolicy{
+		values: a.values,
+	}
+}
+
+type validatingAdmissionPolicy struct {
+	values *Values
+}
+
+func (v *validatingAdmissionPolicy) Name() string {
+	return validatingAdmissionPolicyName
+}
+
+func (v *validatingAdmissionPolicy) New() *admissionregistrationv1.ValidatingAdmissionPolicy {
+	failurePolicy := admissionregistrationv1.Fail
+	return &admissionregistrationv1.ValidatingAdmissionPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ValidatingAdmissionPolicy",
+			APIVersion: "admissionregistration.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: v.Name(),
+			Labels: map[string]string{
+				v.values.OwnerLabelKey: v.values.OwnerLabelValue,
+			},
+		},
+		Spec: admissionregistrationv1.ValidatingAdmissionPolicySpec{
+			FailurePolicy: &failurePolicy,
+			MatchConstraints: &admissionregistrationv1.MatchResources{
+				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+					{
+						RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+							Operations: []admissionregistrationv1.OperationType{
+								admissionregistrationv1.Create,
+							},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{"autoscaling.openshift.io"},
+								APIVersions: []string{"v1"},
+								Resources:   []string{"resourceoverrides"},
+							},
+						},
+					},
+				},
+			},
+			Validations: []admissionregistrationv1.Validation{
+				{
+					Expression: `!(object.metadata.namespace in ['openshift', 'kube', 'kubernetes'] || object.metadata.namespace.startsWith('openshift-') || object.metadata.namespace.startsWith('kube-') || object.metadata.namespace.startsWith('kubernetes-'))`,
+					Message:    "ResourceOverride objects cannot be created in system namespaces (openshift, openshift-*, kube, kube-*, kubernetes, kubernetes-*)",
+				},
+			},
+		},
+	}
+}
+
+func (a *Asset) NewValidatingAdmissionPolicyBinding() *validatingAdmissionPolicyBinding {
+	return &validatingAdmissionPolicyBinding{
+		values: a.values,
+	}
+}
+
+type validatingAdmissionPolicyBinding struct {
+	values *Values
+}
+
+func (v *validatingAdmissionPolicyBinding) Name() string {
+	return validatingAdmissionPolicyName
+}
+
+func (v *validatingAdmissionPolicyBinding) New() *admissionregistrationv1.ValidatingAdmissionPolicyBinding {
+	return &admissionregistrationv1.ValidatingAdmissionPolicyBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ValidatingAdmissionPolicyBinding",
+			APIVersion: "admissionregistration.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: v.Name(),
+			Labels: map[string]string{
+				v.values.OwnerLabelKey: v.values.OwnerLabelValue,
+			},
+		},
+		Spec: admissionregistrationv1.ValidatingAdmissionPolicyBindingSpec{
+			PolicyName: validatingAdmissionPolicyName,
+			ValidationActions: []admissionregistrationv1.ValidationAction{
+				admissionregistrationv1.Deny,
+			},
+		},
+	}
+}

--- a/pkg/clusterresourceoverride/internal/handlers/validatingadmissionpolicy.go
+++ b/pkg/clusterresourceoverride/internal/handlers/validatingadmissionpolicy.go
@@ -1,0 +1,114 @@
+package handlers
+
+import (
+	operatorv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/operator/v1"
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/reference"
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/asset"
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/clusterresourceoverride/internal/condition"
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/ensurer"
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/secondarywatch"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
+	controllerreconciler "sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func NewValidatingAdmissionPolicyHandler(o *Options) *validatingAdmissionPolicyHandler {
+	return &validatingAdmissionPolicyHandler{
+		policyEnsurer:  ensurer.NewValidatingAdmissionPolicyEnsurer(o.Client.Dynamic),
+		bindingEnsurer: ensurer.NewValidatingAdmissionPolicyBindingEnsurer(o.Client.Dynamic),
+		lister:         o.SecondaryLister,
+		asset:          o.Asset,
+	}
+}
+
+type validatingAdmissionPolicyHandler struct {
+	policyEnsurer  *ensurer.ValidatingAdmissionPolicyEnsurer
+	bindingEnsurer *ensurer.ValidatingAdmissionPolicyBindingEnsurer
+	lister         *secondarywatch.Lister
+	asset          *asset.Asset
+}
+
+func (v *validatingAdmissionPolicyHandler) Handle(context *ReconcileRequestContext, original *operatorv1.ClusterResourceOverride) (current *operatorv1.ClusterResourceOverride, result controllerreconciler.Result, handleErr error) {
+	current = original
+
+	// Ensure ValidatingAdmissionPolicy
+	policyEnsure := false
+	policyName := v.asset.NewValidatingAdmissionPolicy().Name()
+	policyObject, err := v.lister.AdmissionRegistrationV1ValidatingAdmissionPolicyLister().Get(policyName)
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			handleErr = condition.NewInstallReadinessError(operatorv1.InternalError, err)
+			return
+		}
+		policyEnsure = true
+	}
+
+	if policyEnsure {
+		desired := v.asset.NewValidatingAdmissionPolicy().New()
+		context.ControllerSetter().Set(desired, original)
+
+		policy, err := v.policyEnsurer.Ensure(desired)
+		if err != nil {
+			handleErr = condition.NewInstallReadinessError(operatorv1.InternalError, err)
+			return
+		}
+
+		policyObject = policy
+		klog.V(2).Infof("key=%s resource=%T/%s successfully created", original.Name, policyObject, policyObject.Name)
+	}
+
+	if ref := original.Status.Resources.ValidatingAdmissionPolicyRef; ref != nil && ref.ResourceVersion == policyObject.ResourceVersion {
+		klog.V(2).Infof("key=%s resource=%T/%s is in sync", original.Name, policyObject, policyObject.Name)
+	} else {
+		newRef, err := reference.GetReference(policyObject)
+		if err != nil {
+			handleErr = condition.NewInstallReadinessError(operatorv1.CannotSetReference, err)
+			return
+		}
+
+		klog.V(2).Infof("key=%s resource=%T/%s resource-version=%s setting object reference", original.Name, policyObject, policyObject.Name, newRef.ResourceVersion)
+		current.Status.Resources.ValidatingAdmissionPolicyRef = newRef
+	}
+
+	// Ensure ValidatingAdmissionPolicyBinding
+	bindingEnsure := false
+	bindingName := v.asset.NewValidatingAdmissionPolicyBinding().Name()
+	bindingObject, err := v.lister.AdmissionRegistrationV1ValidatingAdmissionPolicyBindingLister().Get(bindingName)
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			handleErr = condition.NewInstallReadinessError(operatorv1.InternalError, err)
+			return
+		}
+		bindingEnsure = true
+	}
+
+	if bindingEnsure {
+		desired := v.asset.NewValidatingAdmissionPolicyBinding().New()
+		context.ControllerSetter().Set(desired, original)
+
+		binding, err := v.bindingEnsurer.Ensure(desired)
+		if err != nil {
+			handleErr = condition.NewInstallReadinessError(operatorv1.InternalError, err)
+			return
+		}
+
+		bindingObject = binding
+		klog.V(2).Infof("key=%s resource=%T/%s successfully created", original.Name, bindingObject, bindingObject.Name)
+	}
+
+	if ref := original.Status.Resources.ValidatingAdmissionPolicyBindingRef; ref != nil && ref.ResourceVersion == bindingObject.ResourceVersion {
+		klog.V(2).Infof("key=%s resource=%T/%s is in sync", original.Name, bindingObject, bindingObject.Name)
+		return
+	}
+
+	newRef, err := reference.GetReference(bindingObject)
+	if err != nil {
+		handleErr = condition.NewInstallReadinessError(operatorv1.CannotSetReference, err)
+		return
+	}
+
+	klog.V(2).Infof("key=%s resource=%T/%s resource-version=%s setting object reference", original.Name, bindingObject, bindingObject.Name, newRef.ResourceVersion)
+	current.Status.Resources.ValidatingAdmissionPolicyBindingRef = newRef
+
+	return
+}

--- a/pkg/clusterresourceoverride/internal/reconciler/reconciler.go
+++ b/pkg/clusterresourceoverride/internal/reconciler/reconciler.go
@@ -34,6 +34,7 @@ func NewReconciler(options *handlers.Options) *reconciler {
 		handlers.NewDeploymentReadyHandler(options),
 		handlers.NewAPIServiceHandler(options),
 		handlers.NewWebhookConfigurationHandlerHandler(options),
+		handlers.NewValidatingAdmissionPolicyHandler(options),
 		handlers.NewAvailabilityHandler(options),
 	}
 

--- a/pkg/ensurer/validatingadmissionpolicy.go
+++ b/pkg/ensurer/validatingadmissionpolicy.go
@@ -1,0 +1,59 @@
+package ensurer
+
+import (
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/dynamic"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type ValidatingAdmissionPolicyEnsurer struct {
+	client dynamic.Ensurer
+}
+
+func NewValidatingAdmissionPolicyEnsurer(client dynamic.Ensurer) *ValidatingAdmissionPolicyEnsurer {
+	return &ValidatingAdmissionPolicyEnsurer{
+		client: client,
+	}
+}
+
+func (v *ValidatingAdmissionPolicyEnsurer) Ensure(configuration *admissionregistrationv1.ValidatingAdmissionPolicy) (current *admissionregistrationv1.ValidatingAdmissionPolicy, err error) {
+	unstructured, errGot := v.client.Ensure("validatingadmissionpolicies", configuration)
+	if errGot != nil {
+		err = errGot
+		return
+	}
+
+	current = &admissionregistrationv1.ValidatingAdmissionPolicy{}
+	if conversionErr := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.UnstructuredContent(), current); conversionErr != nil {
+		err = conversionErr
+		return
+	}
+
+	return
+}
+
+type ValidatingAdmissionPolicyBindingEnsurer struct {
+	client dynamic.Ensurer
+}
+
+func NewValidatingAdmissionPolicyBindingEnsurer(client dynamic.Ensurer) *ValidatingAdmissionPolicyBindingEnsurer {
+	return &ValidatingAdmissionPolicyBindingEnsurer{
+		client: client,
+	}
+}
+
+func (v *ValidatingAdmissionPolicyBindingEnsurer) Ensure(configuration *admissionregistrationv1.ValidatingAdmissionPolicyBinding) (current *admissionregistrationv1.ValidatingAdmissionPolicyBinding, err error) {
+	unstructured, errGot := v.client.Ensure("validatingadmissionpolicybindings", configuration)
+	if errGot != nil {
+		err = errGot
+		return
+	}
+
+	current = &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
+	if conversionErr := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructured.UnstructuredContent(), current); conversionErr != nil {
+		err = conversionErr
+		return
+	}
+
+	return
+}

--- a/pkg/secondarywatch/lister.go
+++ b/pkg/secondarywatch/lister.go
@@ -8,14 +8,16 @@ import (
 
 // Lister is a set of Lister(s) for secondary resource(s)
 type Lister struct {
-	deployment     listersappsv1.DeploymentLister
-	daemonset      listersappsv1.DaemonSetLister
-	pod            listerscorev1.PodLister
-	configmap      listerscorev1.ConfigMapLister
-	service        listerscorev1.ServiceLister
-	secret         listerscorev1.SecretLister
-	serviceaccount listerscorev1.ServiceAccountLister
-	webhook        admissionregistrationv1.MutatingWebhookConfigurationLister
+	deployment             listersappsv1.DeploymentLister
+	daemonset              listersappsv1.DaemonSetLister
+	pod                    listerscorev1.PodLister
+	configmap              listerscorev1.ConfigMapLister
+	service                listerscorev1.ServiceLister
+	secret                 listerscorev1.SecretLister
+	serviceaccount         listerscorev1.ServiceAccountLister
+	webhook                admissionregistrationv1.MutatingWebhookConfigurationLister
+	admissionpolicy        admissionregistrationv1.ValidatingAdmissionPolicyLister
+	admissionpolicybinding admissionregistrationv1.ValidatingAdmissionPolicyBindingLister
 }
 
 func (l *Lister) CoreV1ConfigMapLister() listerscorev1.ConfigMapLister {
@@ -40,4 +42,12 @@ func (l *Lister) AppsV1DaemonSetLister() listersappsv1.DaemonSetLister {
 
 func (l *Lister) AdmissionRegistrationV1MutatingWebhookConfigurationLister() admissionregistrationv1.MutatingWebhookConfigurationLister {
 	return l.webhook
+}
+
+func (l *Lister) AdmissionRegistrationV1ValidatingAdmissionPolicyLister() admissionregistrationv1.ValidatingAdmissionPolicyLister {
+	return l.admissionpolicy
+}
+
+func (l *Lister) AdmissionRegistrationV1ValidatingAdmissionPolicyBindingLister() admissionregistrationv1.ValidatingAdmissionPolicyBindingLister {
+	return l.admissionpolicybinding
 }

--- a/pkg/secondarywatch/start.go
+++ b/pkg/secondarywatch/start.go
@@ -42,6 +42,8 @@ func New(options *Options) (lister *Lister, startFunc StarterFunc) {
 	secret := factory.Core().V1().Secrets()
 	serviceaccount := factory.Core().V1().ServiceAccounts()
 	webhook := factory.Admissionregistration().V1().MutatingWebhookConfigurations()
+	admissionpolicy := factory.Admissionregistration().V1().ValidatingAdmissionPolicies()
+	admissionpolicybinding := factory.Admissionregistration().V1().ValidatingAdmissionPolicyBindings()
 
 	apiServerConfigFactory := dynamicinformer.NewDynamicSharedInformerFactory(options.Client.RawDynamic, options.ResyncPeriod)
 	apiServerConfigInformer := apiServerConfigFactory.ForResource(tlsprofile.APIServerGVR).Informer()
@@ -57,6 +59,8 @@ func New(options *Options) (lister *Lister, startFunc StarterFunc) {
 		secret.Informer().AddEventHandler(handler)
 		serviceaccount.Informer().AddEventHandler(handler)
 		webhook.Informer().AddEventHandler(handler)
+		admissionpolicy.Informer().AddEventHandler(handler)
+		admissionpolicybinding.Informer().AddEventHandler(handler)
 
 		if directEnqueuer, ok := enqueuer.(runtime.DirectEnqueuer); ok && options.PrimaryResourceName != "" {
 			apiServerConfigInformer.AddEventHandler(
@@ -82,14 +86,16 @@ func New(options *Options) (lister *Lister, startFunc StarterFunc) {
 	}
 
 	lister = &Lister{
-		deployment:     deployment.Lister(),
-		daemonset:      daemonset.Lister(),
-		pod:            pod.Lister(),
-		configmap:      configmap.Lister(),
-		service:        service.Lister(),
-		secret:         secret.Lister(),
-		serviceaccount: serviceaccount.Lister(),
-		webhook:        webhook.Lister(),
+		deployment:             deployment.Lister(),
+		daemonset:              daemonset.Lister(),
+		pod:                    pod.Lister(),
+		configmap:              configmap.Lister(),
+		service:                service.Lister(),
+		secret:                 secret.Lister(),
+		serviceaccount:         serviceaccount.Lister(),
+		webhook:                webhook.Lister(),
+		admissionpolicy:        admissionpolicy.Lister(),
+		admissionpolicybinding: admissionpolicybinding.Lister(),
 	}
 
 	return

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -1,15 +1,19 @@
 package e2e
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	autoscalingv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/autoscaling/v1"
+	operatorv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/operator/v1"
 	"github.com/openshift/cluster-resource-override-admission-operator/test/helper"
 )
 
@@ -59,18 +63,6 @@ func TestResourceOverrideValidSpec(t *testing.T) {
 			wantStatus: corev1.ConditionFalse,
 			wantReason: "",
 		},
-		{
-			name:      "test-resourceoverride-exempt-namespace",
-			namespace: "openshift-monitoring",
-			spec: autoscalingv1.ResourceOverrideSpec{
-				PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
-					MemoryRequestToLimitPercent: 50,
-					CPURequestToRequestPercent:  50,
-				},
-			},
-			wantStatus: corev1.ConditionTrue,
-			wantReason: autoscalingv1.ExemptNamespace,
-		},
 	}
 
 	client := helper.NewClient(t, options.config)
@@ -93,6 +85,72 @@ func TestResourceOverrideValidSpec(t *testing.T) {
 			if test.wantReason != "" {
 				require.Equal(t, test.wantReason, condition.Reason)
 			}
+		})
+	}
+}
+
+func TestResourceOverrideExemptNamespace(t *testing.T) {
+	exemptNamespaces := []string{
+		"openshift-monitoring",
+		"openshift",
+		"kube-system",
+		"kube",
+		"kubernetes-dashboard",
+		"kubernetes",
+	}
+
+	client := helper.NewClient(t, options.config)
+
+	override := operatorv1.PodResourceOverride{
+		Spec: operatorv1.PodResourceOverrideSpec{
+			LimitCPUToMemoryPercent:     200,
+			CPURequestToLimitPercent:    25,
+			MemoryRequestToLimitPercent: 50,
+		},
+	}
+	current, changed := helper.EnsureAdmissionWebhook(t, client.Operator, "cluster", override, nil)
+	defer helper.RemoveAdmissionWebhook(t, client.Operator, current.GetName())
+	helper.Wait(t, client.Operator, "cluster", helper.GetAvailableConditionFunc(current, changed))
+
+	f := &helper.PreCondition{Client: client.Kubernetes}
+	f.MustHaveValidatingAdmissionPolicy(t)
+
+	assertRejection := func(t *testing.T, namespace string) {
+		t.Helper()
+		err := wait.PollUntilContextTimeout(t.Context(), 10*time.Second, helper.WaitTimeout, true, func(ctx context.Context) (bool, error) {
+			request := &autoscalingv1.ResourceOverride{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-resourceoverride-exempt-namespace",
+					Namespace: namespace,
+				},
+				Spec: autoscalingv1.ResourceOverrideSpec{
+					PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+						MemoryRequestToLimitPercent: 50,
+						CPURequestToRequestPercent:  50,
+					},
+				},
+			}
+
+			_, createErr := client.Operator.AutoscalingV1().ResourceOverrides(namespace).Create(ctx, request, metav1.CreateOptions{})
+			if createErr == nil {
+				// Created successfully when it should have been rejected; clean up and retry
+				_ = client.Operator.AutoscalingV1().ResourceOverrides(namespace).Delete(ctx, request.Name, metav1.DeleteOptions{})
+				t.Logf("VAP not yet enforcing for namespace %s, retrying", namespace)
+				return false, nil
+			}
+			if k8serrors.IsForbidden(createErr) || k8serrors.IsInvalid(createErr) {
+				return true, nil
+			}
+			return false, createErr
+		})
+		require.NoError(t, err, "timed out waiting for VAP to reject ResourceOverride in exempt namespace %s", namespace)
+	}
+
+	for _, namespace := range exemptNamespaces {
+		t.Run(namespace, func(t *testing.T) {
+			ns, nsDisposer := helper.NewExactNamespace(t, client.Kubernetes, namespace)
+			defer nsDisposer.Dispose()
+			assertRejection(t, ns.Name)
 		})
 	}
 }

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -143,6 +143,32 @@ func NewNamespace(t *testing.T, client kubernetes.Interface, name string, optIn 
 	return
 }
 
+// NewExactNamespace gets or creates a namespace with the given name. Only use when the exact name matters (e.g. testing system namespace policies). Prefer NewNamespace for all other tests.
+func NewExactNamespace(t *testing.T, client kubernetes.Interface, name string) (ns *corev1.Namespace, disposer Disposer) {
+	created := false
+	object, err := client.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		request := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		}
+		object, err = client.CoreV1().Namespaces().Create(context.TODO(), request, metav1.CreateOptions{})
+		created = true
+	}
+	require.NoError(t, err)
+	require.NotNil(t, object)
+
+	ns = object
+	disposer = func() {
+		if created {
+			err := client.CoreV1().Namespaces().Delete(context.TODO(), object.Name, metav1.DeleteOptions{})
+			require.NoError(t, err)
+		}
+	}
+	return
+}
+
 func NewPod(t *testing.T, client kubernetes.Interface, namespace string, spec corev1.PodSpec) (pod *corev1.Pod, disposer Disposer) {
 	request := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/helper/precondition.go
+++ b/test/helper/precondition.go
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	webhookName = "clusterresourceoverrides.admission.autoscaling.openshift.io"
+	webhookName                   = "clusterresourceoverrides.admission.autoscaling.openshift.io"
+	validatingAdmissionPolicyName = "resourceoverride-exempt-namespace"
 )
 
 type PreCondition struct {
@@ -60,5 +61,20 @@ func (f *PreCondition) MustHaveClusterResourceOverrideAdmissionConfiguration(t *
 
 	require.NoErrorf(t, err, "MutatingWebhookConfiguration %s resource not found in /apis/admissionregistration.k8s.io/v1 discovery document", webhookName)
 	require.NoErrorf(t, pollErr, "MutatingWebhookConfiguration %s resource not found in /apis/admissionregistration.k8s.io/v1 discovery document prior to timeout", webhookName)
+	require.NotNil(t, configuration)
+}
+
+func (f *PreCondition) MustHaveValidatingAdmissionPolicy(t *testing.T) {
+	t.Logf("fetching ValidatingAdmissionPolicy %s", validatingAdmissionPolicyName)
+
+	var configuration *admissionregistrationv1.ValidatingAdmissionPolicy
+	var err error
+	pollErr := wait.Poll(WaitInterval, WaitTimeout, func() (bool, error) {
+		configuration, err = f.Client.AdmissionregistrationV1().ValidatingAdmissionPolicies().Get(context.TODO(), validatingAdmissionPolicyName, metav1.GetOptions{})
+		return (err == nil && configuration != nil), nil
+	})
+
+	require.NoErrorf(t, err, "ValidatingAdmissionPolicy %s resource not found", validatingAdmissionPolicyName)
+	require.NoErrorf(t, pollErr, "ValidatingAdmissionPolicy %s resource not found prior to timeout", validatingAdmissionPolicyName)
 	require.NotNil(t, configuration)
 }


### PR DESCRIPTION
Jira reference: [OCPBUGS-104560](https://redhat.atlassian.net/browse/OCPBUGS-104560?search_id=3347198b-4b47-4e5a-a6a6-2ab072780ca4)

In order to prevent users from creating resourceoverride objects in namespaces with pods we don't want to override, we decided to use VAP/VAPB resources to enforce this. Previously, we tried using CEL validation, but it does not have access to namespace fields. Furthermore we also attempted using OLM for the lifecycle management of the VAP/VAPB resources, but it does not recognize them. Because of that, we are letting the operator create these resources and manage their lifecycles.

The CRO controller was chosen over the ResourceOverride controller for handling the lifecycle because ResourceOverrides are namespaced resources, which cannot own cluster-scoped VAP/VAPB objects via owner references, which would prevent garbage collection from working correctly. The CRO controller already manages necessary cluster-scoped singleton resources (MutatingWebhookConfiguration, APIService) using this same pattern.

The following changes were made to the operator:
- Manage a ValidatingAdmissionPolicy and binding from the CRO controller's handler chain to reject ResourceOverride creation in system namespaces (openshift[-*], kube[-*], kubernetes[-*]) at admission time
- Follow existing asset/ensurer/handler pattern with owner references to handle garbage collection
- Add RBAC permissions for VAP/VAPB to deploy ClusterRole and CSV
- Add secondary watch informers and listers for VAP/VAPB resources
- Update e2e tests to validate admission rejection instead of post-creation status conditions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added automatic creation and management of validating admission policies and bindings.
- ResourceOverride creation is blocked in designated system namespaces.
- Added configuration references for associated admission policy resources.
- Added permissions and monitoring required to manage these admission resources.

## Bug Fixes
- Required policies and bindings are recreated or updated when missing or changed.

## Tests
- Added end-to-end coverage confirming ResourceOverride requests are rejected in exempt namespaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->