### PR TITLE
OCPBUGS-104565: add ignored status condition for ResourceOverride

### DIFF
--- a/pkg/apis/autoscaling/v1/override_types.go
+++ b/pkg/apis/autoscaling/v1/override_types.go
@@ -13,11 +13,12 @@ type ResourceOverrideConditionType string
 
 const (
 	ValidationFailure ResourceOverrideConditionType = "ValidationFailure"
+	Ignored           ResourceOverrideConditionType = "Ignored"
 )
 
 const (
-	InvalidParameters = "InvalidParameters"
-	ExemptNamespace   = "ExemptNamespace"
+	InvalidParameters   = "InvalidParameters"
+	NamespaceNotOptedIn = "NamespaceNotOptedIn"
 )
 
 type ResourceOverrideCondition struct {

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -7,6 +7,10 @@ import (
 	"github.com/openshift/cluster-resource-override-admission-operator/pkg/runtime"
 )
 
+const (
+	NamespaceOptInLabelKey = "clusterresourceoverrides.admission.autoscaling.openshift.io/enabled"
+)
+
 func New(context runtime.OperandContext) *Asset {
 	values := &Values{
 		Name:                           context.WebhookName(),
@@ -17,6 +21,7 @@ func New(context runtime.OperandContext) *Asset {
 		AdmissionAPIGroup:              "admission.autoscaling.openshift.io",
 		AdmissionAPIVersion:            "v1",
 		AdmissionAPIResource:           "clusterresourceoverrides",
+		NamespaceOptInLabelKey:         NamespaceOptInLabelKey,
 		OwnerLabelKey:                  "operator.autoscaling.openshift.io/clusterresourceoverride",
 		OwnerLabelValue:                "true",
 		SelectorLabelKey:               "clusterresourceoverride",
@@ -42,19 +47,20 @@ func (a *Asset) Values() *Values {
 }
 
 type Values struct {
-	Name                 string
-	Namespace            string
-	ServiceAccountName   string
-	OperandImage         string
-	OperandVersion       string
-	AdmissionAPIGroup    string
-	AdmissionAPIVersion  string
-	AdmissionAPIResource string
-	OwnerLabelKey        string
-	OwnerLabelValue      string
-	SelectorLabelKey     string
-	SelectorLabelValue   string
-	ConfigurationKey     string
+	Name                   string
+	Namespace              string
+	ServiceAccountName     string
+	OperandImage           string
+	OperandVersion         string
+	AdmissionAPIGroup      string
+	AdmissionAPIVersion    string
+	AdmissionAPIResource   string
+	NamespaceOptInLabelKey string
+	OwnerLabelKey          string
+	OwnerLabelValue        string
+	SelectorLabelKey       string
+	SelectorLabelValue     string
+	ConfigurationKey       string
 
 	ConfigurationHashAnnotationKey string
 	ServingCertHashAnnotationKey   string

--- a/pkg/operator/run.go
+++ b/pkg/operator/run.go
@@ -83,13 +83,18 @@ func (r *runner) Run(config *Config, errorCh chan<- error) {
 		return
 	}
 
-	ro, err := resourceoverride.New(&resourceoverride.Options{
+	ro, nsWatchStarter, err := resourceoverride.New(&resourceoverride.Options{
 		ResyncPeriod: DefaultResyncPeriodPrimaryResource,
 		Workers:      DefaultWorkerCount,
 		Client:       clients,
 	})
 	if err != nil {
 		errorCh <- fmt.Errorf("failed to create resourceoverride controller - %s", err.Error())
+		return
+	}
+
+	if err := nsWatchStarter(config.ShutdownContext); err != nil {
+		errorCh <- fmt.Errorf("failed to start namespace watch for resourceoverride controller - %s", err.Error())
 		return
 	}
 

--- a/pkg/resourceoverride/controller.go
+++ b/pkg/resourceoverride/controller.go
@@ -3,11 +3,13 @@ package resourceoverride
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	controllerreconciler "sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -29,12 +31,11 @@ type Options struct {
 	Client       *operatorruntime.Client
 }
 
-func New(options *Options) (c controller.Interface, err error) {
-	if options == nil || options.Client == nil {
+func New(options *Options) (c controller.Interface, nsWatchStarter NamespaceWatchStarterFunc, err error) {
+	if options == nil || options.Client == nil || options.Client.Operator == nil || options.Client.Kubernetes == nil {
 		err = errors.New("Invalid input to controller.New")
 		return
 	}
-
 	client := options.Client.Operator
 	watcher := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -58,7 +59,27 @@ func New(options *Options) (c controller.Interface, err error) {
 
 	lister := listers.NewResourceOverrideLister(store.(cache.Indexer))
 
-	reconciler := reconciler.NewReconciler(client, lister)
+	nsFactory := informers.NewSharedInformerFactory(options.Client.Kubernetes, options.ResyncPeriod)
+	nsInformer := nsFactory.Core().V1().Namespaces()
+	namespaceLister := nsInformer.Lister()
+
+	nsInformer.Informer().AddEventHandler(&namespaceEventHandler{
+		roLister: lister,
+		queue:    queue,
+	})
+
+	nsWatchStarter = func(ctx context.Context) error {
+		nsFactory.Start(ctx.Done())
+		status := nsFactory.WaitForCacheSync(ctx.Done())
+		for objType, synced := range status {
+			if !synced {
+				return fmt.Errorf("namespace informer cache sync failed for %s", objType.Name())
+			}
+		}
+		return nil
+	}
+
+	reconciler := reconciler.NewReconciler(client, lister, namespaceLister)
 
 	c = &resourceOverrideController{
 		workers:    options.Workers,

--- a/pkg/resourceoverride/controller_test.go
+++ b/pkg/resourceoverride/controller_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
 	"github.com/openshift/cluster-resource-override-admission-operator/pkg/generated/clientset/versioned/fake"
 	operatorruntime "github.com/openshift/cluster-resource-override-admission-operator/pkg/runtime"
 )
@@ -33,12 +35,24 @@ func TestNew(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "nil kubernetes client",
+			options: &Options{
+				ResyncPeriod: 10 * time.Minute,
+				Workers:      1,
+				Client: &operatorruntime.Client{
+					Operator: fake.NewSimpleClientset(),
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "valid options",
 			options: &Options{
 				ResyncPeriod: 10 * time.Minute,
 				Workers:      2,
 				Client: &operatorruntime.Client{
-					Operator: fake.NewSimpleClientset(),
+					Operator:   fake.NewSimpleClientset(),
+					Kubernetes: kubefake.NewSimpleClientset(),
 				},
 			},
 			wantErr:     false,
@@ -49,7 +63,7 @@ func TestNew(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			c, err := New(test.options)
+			c, _, err := New(test.options)
 			if test.wantErr {
 				require.Error(t, err)
 				require.Nil(t, c)

--- a/pkg/resourceoverride/internal/condition/builder.go
+++ b/pkg/resourceoverride/internal/condition/builder.go
@@ -53,6 +53,34 @@ func (b *Builder) WithValidationCleared() (builder *Builder) {
 	return b
 }
 
+func (b *Builder) WithIgnored(reason string, message string) (builder *Builder) {
+	b.init()
+
+	desired := &autoscalingv1.ResourceOverrideCondition{
+		Type:               autoscalingv1.Ignored,
+		Status:             corev1.ConditionTrue,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.NewTime(b.clock.Now()),
+	}
+	b.WithCondition(desired)
+
+	return b
+}
+
+func (b *Builder) WithIgnoredCleared() (builder *Builder) {
+	b.init()
+
+	desired := &autoscalingv1.ResourceOverrideCondition{
+		Type:               autoscalingv1.Ignored,
+		Status:             corev1.ConditionFalse,
+		LastTransitionTime: metav1.NewTime(b.clock.Now()),
+	}
+	b.WithCondition(desired)
+
+	return b
+}
+
 func (b *Builder) WithCondition(desired *autoscalingv1.ResourceOverrideCondition) {
 	if desired == nil {
 		return

--- a/pkg/resourceoverride/internal/condition/builder_test.go
+++ b/pkg/resourceoverride/internal/condition/builder_test.go
@@ -132,13 +132,13 @@ func TestFind(t *testing.T) {
 				{
 					Type:   autoscalingv1.ValidationFailure,
 					Status: corev1.ConditionTrue,
-					Reason: autoscalingv1.ExemptNamespace,
+					Reason: autoscalingv1.InvalidParameters,
 				},
 			},
 		}
 		result := Find(status, autoscalingv1.ValidationFailure)
 		require.NotNil(t, result)
-		require.Equal(t, autoscalingv1.ExemptNamespace, result.Reason)
+		require.Equal(t, autoscalingv1.InvalidParameters, result.Reason)
 	})
 }
 

--- a/pkg/resourceoverride/internal/reconciler/reconciler.go
+++ b/pkg/resourceoverride/internal/reconciler/reconciler.go
@@ -3,15 +3,16 @@ package reconciler
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	autoscalingv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/autoscaling/v1"
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/asset"
 	"github.com/openshift/cluster-resource-override-admission-operator/pkg/generated/clientset/versioned"
 	autoscalingv1listers "github.com/openshift/cluster-resource-override-admission-operator/pkg/generated/listers/autoscaling/v1"
 	"github.com/openshift/cluster-resource-override-admission-operator/pkg/resourceoverride/internal/condition"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 	controllerreconciler "sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -25,15 +26,17 @@ var (
 )
 
 type reconciler struct {
-	client  versioned.Interface
-	lister  autoscalingv1listers.ResourceOverrideLister
-	updater *StatusUpdater
+	client          versioned.Interface
+	lister          autoscalingv1listers.ResourceOverrideLister
+	namespaceLister corev1listers.NamespaceLister
+	updater         *StatusUpdater
 }
 
-func NewReconciler(client versioned.Interface, lister autoscalingv1listers.ResourceOverrideLister) *reconciler {
+func NewReconciler(client versioned.Interface, lister autoscalingv1listers.ResourceOverrideLister, namespaceLister corev1listers.NamespaceLister) *reconciler {
 	return &reconciler{
-		client: client,
-		lister: lister,
+		client:          client,
+		lister:          lister,
+		namespaceLister: namespaceLister,
 		updater: &StatusUpdater{
 			client: client,
 		},
@@ -61,6 +64,12 @@ func (r *reconciler) Reconcile(ctx context.Context, request controllerreconciler
 
 	Validate(copy)
 
+	if nsErr := r.checkNamespaceOptIn(copy); nsErr != nil {
+		klog.Errorf("[reconciler] key=%s failed to check namespace opt-in - %s", request.Name, nsErr.Error())
+		err = nsErr
+		return
+	}
+
 	err = r.updater.Update(original, copy)
 	if err != nil {
 		klog.Errorf("[reconciler] key=%s failed to update status - %s", request.Name, err.Error())
@@ -71,11 +80,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request controllerreconciler
 
 func Validate(current *autoscalingv1.ResourceOverride) {
 	builder := condition.NewBuilderWithStatus(&current.Status)
-
-	if isExemptNamespace(current.Namespace) {
-		builder.WithValidationFailure(autoscalingv1.ExemptNamespace, fmt.Sprintf("resourceoverride %s/%s is in an exempt namespace", current.Namespace, current.Name))
-		return
-	}
 
 	validationErr := current.Spec.PodResourceOverride.Validate()
 	if validationErr != nil {
@@ -93,12 +97,18 @@ func Validate(current *autoscalingv1.ResourceOverride) {
 	builder.WithValidationCleared()
 }
 
-func isExemptNamespace(namespace string) bool {
-	switch namespace {
-	case "openshift", "kube", "kubernetes":
-		return true
+func (r *reconciler) checkNamespaceOptIn(current *autoscalingv1.ResourceOverride) error {
+	ns, err := r.namespaceLister.Get(current.Namespace)
+	if err != nil {
+		return err
 	}
-	return strings.HasPrefix(namespace, "openshift-") ||
-		strings.HasPrefix(namespace, "kube-") ||
-		strings.HasPrefix(namespace, "kubernetes-")
+
+	builder := condition.NewBuilderWithStatus(&current.Status)
+	if ns.Labels[asset.NamespaceOptInLabelKey] != "true" {
+		builder.WithIgnored(autoscalingv1.NamespaceNotOptedIn, fmt.Sprintf("namespace %q does not have the %s=true label", current.Namespace, asset.NamespaceOptInLabelKey))
+		return nil
+	}
+
+	builder.WithIgnoredCleared()
+	return nil
 }

--- a/pkg/resourceoverride/internal/reconciler/reconciler_test.go
+++ b/pkg/resourceoverride/internal/reconciler/reconciler_test.go
@@ -1,7 +1,6 @@
 package reconciler
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,39 +8,23 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	controllerreconciler "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	autoscalingv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/autoscaling/v1"
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/asset"
 	"github.com/openshift/cluster-resource-override-admission-operator/pkg/generated/clientset/versioned/fake"
 	autoscalingv1listers "github.com/openshift/cluster-resource-override-admission-operator/pkg/generated/listers/autoscaling/v1"
 	"github.com/openshift/cluster-resource-override-admission-operator/pkg/resourceoverride/internal/condition"
 )
 
-func TestIsExemptNamespace(t *testing.T) {
-	tests := []struct {
-		namespace string
-		want      bool
-	}{
-		{"default", false},
-		{"my-namespace", false},
-		{"mykube-system", false},
-		{"openshift", true},
-		{"openshift-monitoring", true},
-		{"openshift-operators", true},
-		{"kube", true},
-		{"kube-system", true},
-		{"kube-public", true},
-		{"kubernetes", true},
-		{"kubernetes-dashboard", true},
+func newNamespaceLister(namespaces ...*corev1.Namespace) corev1listers.NamespaceLister {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, ns := range namespaces {
+		indexer.Add(ns)
 	}
-
-	for _, test := range tests {
-		t.Run(test.namespace, func(t *testing.T) {
-			got := isExemptNamespace(test.namespace)
-			require.Equal(t, test.want, got)
-		})
-	}
+	return corev1listers.NewNamespaceLister(indexer)
 }
 
 func TestValidate(t *testing.T) {
@@ -84,22 +67,6 @@ func TestValidate(t *testing.T) {
 			},
 			wantStatus: corev1.ConditionFalse,
 			wantReason: "",
-		},
-		{
-			name: "exempt namespace",
-			ro: &autoscalingv1.ResourceOverride{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "openshift-monitoring",
-				},
-				Spec: autoscalingv1.ResourceOverrideSpec{
-					PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
-						MemoryRequestToLimitPercent: 50,
-					},
-				},
-			},
-			wantStatus: corev1.ConditionTrue,
-			wantReason: autoscalingv1.ExemptNamespace,
 		},
 		{
 			name: "invalid spec - out of range",
@@ -156,7 +123,7 @@ func TestValidate(t *testing.T) {
 }
 
 func TestReconcile(t *testing.T) {
-	t.Run("valid RO updates status", func(t *testing.T) {
+	t.Run("valid RO in opted-in namespace", func(t *testing.T) {
 		ro := &autoscalingv1.ResourceOverride{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-ro",
@@ -169,34 +136,89 @@ func TestReconcile(t *testing.T) {
 			},
 		}
 
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "default",
+				Labels: map[string]string{asset.NamespaceOptInLabelKey: "true"},
+			},
+		}
+
 		fakeClient := fake.NewSimpleClientset(ro)
 		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 		indexer.Add(ro)
 		lister := autoscalingv1listers.NewResourceOverrideLister(indexer)
+		nsLister := newNamespaceLister(ns)
 
-		r := NewReconciler(fakeClient, lister)
-		result, err := r.Reconcile(context.TODO(), controllerreconciler.Request{
+		r := NewReconciler(fakeClient, lister, nsLister)
+		result, err := r.Reconcile(t.Context(), controllerreconciler.Request{
 			NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-ro"},
 		})
 
 		require.NoError(t, err)
 		require.Equal(t, controllerreconciler.Result{}, result)
 
-		updated, getErr := fakeClient.AutoscalingV1().ResourceOverrides("default").Get(context.TODO(), "test-ro", metav1.GetOptions{})
+		updated, getErr := fakeClient.AutoscalingV1().ResourceOverrides("default").Get(t.Context(), "test-ro", metav1.GetOptions{})
 		require.NoError(t, getErr)
 
-		cond := condition.Find(&updated.Status, autoscalingv1.ValidationFailure)
-		require.NotNil(t, cond)
-		require.Equal(t, corev1.ConditionFalse, cond.Status)
+		validationCond := condition.Find(&updated.Status, autoscalingv1.ValidationFailure)
+		require.NotNil(t, validationCond)
+		require.Equal(t, corev1.ConditionFalse, validationCond.Status)
+
+		ignoredCond := condition.Find(&updated.Status, autoscalingv1.Ignored)
+		require.NotNil(t, ignoredCond)
+		require.Equal(t, corev1.ConditionFalse, ignoredCond.Status)
+	})
+
+	t.Run("valid RO in non-opted-in namespace", func(t *testing.T) {
+		ro := &autoscalingv1.ResourceOverride{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-ro",
+				Namespace: "default",
+			},
+			Spec: autoscalingv1.ResourceOverrideSpec{
+				PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+					MemoryRequestToLimitPercent: 50,
+				},
+			},
+		}
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+			},
+		}
+
+		fakeClient := fake.NewSimpleClientset(ro)
+		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		indexer.Add(ro)
+		lister := autoscalingv1listers.NewResourceOverrideLister(indexer)
+		nsLister := newNamespaceLister(ns)
+
+		r := NewReconciler(fakeClient, lister, nsLister)
+		result, err := r.Reconcile(t.Context(), controllerreconciler.Request{
+			NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-ro"},
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, controllerreconciler.Result{}, result)
+
+		updated, getErr := fakeClient.AutoscalingV1().ResourceOverrides("default").Get(t.Context(), "test-ro", metav1.GetOptions{})
+		require.NoError(t, getErr)
+
+		ignoredCond := condition.Find(&updated.Status, autoscalingv1.Ignored)
+		require.NotNil(t, ignoredCond)
+		require.Equal(t, corev1.ConditionTrue, ignoredCond.Status)
+		require.Equal(t, autoscalingv1.NamespaceNotOptedIn, ignoredCond.Reason)
 	})
 
 	t.Run("not found returns no error", func(t *testing.T) {
 		fakeClient := fake.NewSimpleClientset()
 		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 		lister := autoscalingv1listers.NewResourceOverrideLister(indexer)
+		nsLister := newNamespaceLister()
 
-		r := NewReconciler(fakeClient, lister)
-		_, err := r.Reconcile(context.TODO(), controllerreconciler.Request{
+		r := NewReconciler(fakeClient, lister, nsLister)
+		_, err := r.Reconcile(t.Context(), controllerreconciler.Request{
 			NamespacedName: types.NamespacedName{Namespace: "default", Name: "nonexistent"},
 		})
 
@@ -216,20 +238,28 @@ func TestReconcile(t *testing.T) {
 			},
 		}
 
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "default",
+				Labels: map[string]string{asset.NamespaceOptInLabelKey: "true"},
+			},
+		}
+
 		fakeClient := fake.NewSimpleClientset(ro)
 		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 		indexer.Add(ro)
 		lister := autoscalingv1listers.NewResourceOverrideLister(indexer)
+		nsLister := newNamespaceLister(ns)
 
-		r := NewReconciler(fakeClient, lister)
-		result, err := r.Reconcile(context.TODO(), controllerreconciler.Request{
+		r := NewReconciler(fakeClient, lister, nsLister)
+		result, err := r.Reconcile(t.Context(), controllerreconciler.Request{
 			NamespacedName: types.NamespacedName{Namespace: "default", Name: "test-ro-invalid"},
 		})
 
 		require.NoError(t, err)
 		require.Equal(t, controllerreconciler.Result{}, result)
 
-		updated, getErr := fakeClient.AutoscalingV1().ResourceOverrides("default").Get(context.TODO(), "test-ro-invalid", metav1.GetOptions{})
+		updated, getErr := fakeClient.AutoscalingV1().ResourceOverrides("default").Get(t.Context(), "test-ro-invalid", metav1.GetOptions{})
 		require.NoError(t, getErr)
 
 		cond := condition.Find(&updated.Status, autoscalingv1.ValidationFailure)

--- a/pkg/resourceoverride/namespace_handler.go
+++ b/pkg/resourceoverride/namespace_handler.go
@@ -1,0 +1,58 @@
+package resourceoverride
+
+import (
+	"context"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	controllerreconciler "sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	listers "github.com/openshift/cluster-resource-override-admission-operator/pkg/generated/listers/autoscaling/v1"
+)
+
+// NamespaceWatchStarterFunc starts the namespace informer and waits for cache sync.
+type NamespaceWatchStarterFunc func(ctx context.Context) error
+
+type namespaceEventHandler struct {
+	roLister listers.ResourceOverrideLister
+	queue    workqueue.RateLimitingInterface
+}
+
+func (h *namespaceEventHandler) OnAdd(obj interface{}, isInInitialList bool) {}
+
+func (h *namespaceEventHandler) OnUpdate(oldObj, newObj interface{}) {
+	oldNs, ok := oldObj.(*corev1.Namespace)
+	if !ok {
+		return
+	}
+	newNs, ok := newObj.(*corev1.Namespace)
+	if !ok {
+		return
+	}
+
+	if reflect.DeepEqual(oldNs.Labels, newNs.Labels) {
+		return
+	}
+
+	ros, err := h.roLister.ResourceOverrides(newNs.Name).List(labels.Everything())
+	if err != nil || len(ros) == 0 {
+		return
+	}
+
+	for _, ro := range ros {
+		h.queue.Add(controllerreconciler.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: ro.Namespace,
+				Name:      ro.Name,
+			},
+		})
+	}
+
+	klog.V(4).Infof("[resourceoverride] namespace=%s labels changed, enqueued %d ResourceOverride(s)", newNs.Name, len(ros))
+}
+
+func (h *namespaceEventHandler) OnDelete(obj interface{}) {}

--- a/pkg/resourceoverride/namespace_handler_test.go
+++ b/pkg/resourceoverride/namespace_handler_test.go
@@ -1,0 +1,109 @@
+package resourceoverride
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	controllerreconciler "sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	autoscalingv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/autoscaling/v1"
+	listers "github.com/openshift/cluster-resource-override-admission-operator/pkg/generated/listers/autoscaling/v1"
+)
+
+func newTestROLister(ros ...*autoscalingv1.ResourceOverride) listers.ResourceOverrideLister {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, ro := range ros {
+		indexer.Add(ro)
+	}
+	return listers.NewResourceOverrideLister(indexer)
+}
+
+func TestNamespaceEventHandlerOnUpdate(t *testing.T) {
+	tests := []struct {
+		name         string
+		oldNs        *corev1.Namespace
+		newNs        *corev1.Namespace
+		ros          []*autoscalingv1.ResourceOverride
+		wantEnqueued int
+	}{
+		{
+			name: "labels changed with ROs in namespace",
+			oldNs: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-ns"},
+			},
+			newNs: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-ns",
+					Labels: map[string]string{"some-label": "true"},
+				},
+			},
+			ros: []*autoscalingv1.ResourceOverride{
+				{ObjectMeta: metav1.ObjectMeta{Name: "ro-1", Namespace: "test-ns"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "ro-2", Namespace: "test-ns"}},
+			},
+			wantEnqueued: 2,
+		},
+		{
+			name: "labels unchanged",
+			oldNs: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-ns",
+					Labels: map[string]string{"key": "value"},
+				},
+			},
+			newNs: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test-ns",
+					Labels: map[string]string{"key": "value"},
+				},
+			},
+			ros: []*autoscalingv1.ResourceOverride{
+				{ObjectMeta: metav1.ObjectMeta{Name: "ro-1", Namespace: "test-ns"}},
+			},
+			wantEnqueued: 0,
+		},
+		{
+			name: "labels changed but no ROs in namespace",
+			oldNs: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "empty-ns"},
+			},
+			newNs: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "empty-ns",
+					Labels: map[string]string{"added": "true"},
+				},
+			},
+			ros:          nil,
+			wantEnqueued: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+			defer queue.ShutDown()
+
+			handler := &namespaceEventHandler{
+				roLister: newTestROLister(test.ros...),
+				queue:    queue,
+			}
+
+			handler.OnUpdate(test.oldNs, test.newNs)
+
+			require.Equal(t, test.wantEnqueued, queue.Len())
+
+			for _, ro := range test.ros[:test.wantEnqueued] {
+				item, _ := queue.Get()
+				req := item.(controllerreconciler.Request)
+				require.Equal(t, types.NamespacedName{Namespace: ro.Namespace, Name: ro.Name}, req.NamespacedName)
+				queue.Done(item)
+			}
+		})
+	}
+}

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	autoscalingv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/autoscaling/v1"
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/asset"
 	"github.com/openshift/cluster-resource-override-admission-operator/test/helper"
 )
 
@@ -59,42 +60,91 @@ func TestResourceOverrideValidSpec(t *testing.T) {
 			wantStatus: corev1.ConditionFalse,
 			wantReason: "",
 		},
-		{
-			name:      "test-resourceoverride-exempt-namespace",
-			namespace: "openshift-monitoring",
-			spec: autoscalingv1.ResourceOverrideSpec{
-				PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
-					MemoryRequestToLimitPercent: 50,
-					CPURequestToRequestPercent:  50,
-				},
-			},
-			wantStatus: corev1.ConditionTrue,
-			wantReason: autoscalingv1.ExemptNamespace,
-		},
 	}
 
 	client := helper.NewClient(t, options.config)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ns, nsDisposer := helper.NewNamespace(t, client.Kubernetes, test.namespace, false)
+			ns, nsDisposer := helper.NewNamespace(t, client.Kubernetes, test.namespace, true)
 			defer nsDisposer.Dispose()
 
 			_, roDisposer := helper.CreateResourceOverride(t, client.Operator, ns.Name, test.name, test.spec)
 			defer roDisposer.Dispose()
 
 			ro := helper.WaitForResourceOverrideCondition(t, client.Operator, ns.Name, test.name, func(override *autoscalingv1.ResourceOverride) bool {
-				condition := helper.GetResourceOverrideCondition(override, autoscalingv1.ValidationFailure)
-				return condition != nil
+				validation := helper.GetResourceOverrideCondition(override, autoscalingv1.ValidationFailure)
+				ignored := helper.GetResourceOverrideCondition(override, autoscalingv1.Ignored)
+				return validation != nil && ignored != nil
 			})
 
-			condition := helper.GetResourceOverrideCondition(ro, autoscalingv1.ValidationFailure)
-			require.Equal(t, test.wantStatus, condition.Status)
+			validation := helper.GetResourceOverrideCondition(ro, autoscalingv1.ValidationFailure)
+			require.Equal(t, test.wantStatus, validation.Status)
 			if test.wantReason != "" {
-				require.Equal(t, test.wantReason, condition.Reason)
+				require.Equal(t, test.wantReason, validation.Reason)
 			}
+
+			ignored := helper.GetResourceOverrideCondition(ro, autoscalingv1.Ignored)
+			require.Equal(t, corev1.ConditionFalse, ignored.Status, "Ignored condition should be False in opted-in namespace")
 		})
 	}
+}
+
+func TestResourceOverrideIgnoredCondition(t *testing.T) {
+	client := helper.NewClient(t, options.config)
+
+	ns, nsDisposer := helper.NewNamespace(t, client.Kubernetes, "test-ignored", false)
+	defer nsDisposer.Dispose()
+
+	_, roDisposer := helper.CreateResourceOverride(t, client.Operator, ns.Name, "test-ignored-ro", autoscalingv1.ResourceOverrideSpec{
+		PodResourceOverride: autoscalingv1.PodResourceOverrideSpec{
+			MemoryRequestToLimitPercent: 50,
+			CPURequestToRequestPercent:  50,
+		},
+	})
+	defer roDisposer.Dispose()
+
+	// Namespace does not have the opt-in label, so the Ignored condition should be True.
+	ro := helper.WaitForResourceOverrideCondition(t, client.Operator, ns.Name, "test-ignored-ro", func(override *autoscalingv1.ResourceOverride) bool {
+		cond := helper.GetResourceOverrideCondition(override, autoscalingv1.Ignored)
+		return cond != nil && cond.Status == corev1.ConditionTrue
+	})
+	cond := helper.GetResourceOverrideCondition(ro, autoscalingv1.Ignored)
+	require.Equal(t, corev1.ConditionTrue, cond.Status)
+	require.Equal(t, autoscalingv1.NamespaceNotOptedIn, cond.Reason)
+
+	// Add the opt-in label to the namespace.
+	ns, err := client.Kubernetes.CoreV1().Namespaces().Get(t.Context(), ns.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	ns.Labels = map[string]string{
+		asset.NamespaceOptInLabelKey: "true",
+	}
+	ns, err = client.Kubernetes.CoreV1().Namespaces().Update(t.Context(), ns, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// The Ignored condition should flip to False.
+	ro = helper.WaitForResourceOverrideCondition(t, client.Operator, ns.Name, "test-ignored-ro", func(override *autoscalingv1.ResourceOverride) bool {
+		cond := helper.GetResourceOverrideCondition(override, autoscalingv1.Ignored)
+		return cond != nil && cond.Status == corev1.ConditionFalse
+	})
+	cond = helper.GetResourceOverrideCondition(ro, autoscalingv1.Ignored)
+	require.Equal(t, corev1.ConditionFalse, cond.Status)
+
+	// Remove the opt-in label from the namespace.
+	ns, err = client.Kubernetes.CoreV1().Namespaces().Get(t.Context(), ns.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	ns.Labels = map[string]string{}
+	ns, err = client.Kubernetes.CoreV1().Namespaces().Update(t.Context(), ns, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// The Ignored condition should flip back to True.
+	ro = helper.WaitForResourceOverrideCondition(t, client.Operator, ns.Name, "test-ignored-ro", func(override *autoscalingv1.ResourceOverride) bool {
+		cond := helper.GetResourceOverrideCondition(override, autoscalingv1.Ignored)
+		return cond != nil && cond.Status == corev1.ConditionTrue
+	})
+	cond = helper.GetResourceOverrideCondition(ro, autoscalingv1.Ignored)
+	require.Equal(t, corev1.ConditionTrue, cond.Status)
+	require.Equal(t, autoscalingv1.NamespaceNotOptedIn, cond.Reason)
 }
 
 func TestResourceOverrideInvalidCRDSpec(t *testing.T) {

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -26,6 +26,7 @@ import (
 
 	autoscalingv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/autoscaling/v1"
 	operatorv1 "github.com/openshift/cluster-resource-override-admission-operator/pkg/apis/operator/v1"
+	"github.com/openshift/cluster-resource-override-admission-operator/pkg/asset"
 	"github.com/openshift/cluster-resource-override-admission-operator/pkg/generated/clientset/versioned"
 	"github.com/openshift/cluster-resource-override-admission-operator/pkg/tlsprofile"
 )
@@ -127,7 +128,7 @@ func NewNamespace(t *testing.T, client kubernetes.Interface, name string, optIn 
 
 	if optIn {
 		request.ObjectMeta.Labels = map[string]string{
-			"clusterresourceoverrides.admission.autoscaling.openshift.io/enabled": "true",
+			asset.NamespaceOptInLabelKey: "true",
 		}
 	}
 


### PR DESCRIPTION
Jira reference: [OCPBUGS-104565](https://redhat.atlassian.net/browse/OCPBUGS-104565?search_id=3347198b-4b47-4e5a-a6a6-2ab072780ca4)

ResourceOverride objects created in namespaces without the CRO opt-in label were silently ignored with no user-visible signal. With VAP/VAPB now handling exempt namespace blocking at admission ([OCPBUGS-104560](https://redhat.atlassian.net/browse/AUTOSCALE-958)), the old isExemptNamespace reconciler check is obsolete. This takes it's place with an Ignored status condition that tells users their ResourceOverride is not being applied when in a namespace that lacks the opt-in label.

The opt-in label key (clusterresourceoverrides.admission.autoscaling.openshift.io/enabled) is now defined once as asset.NamespaceOptInLabelKey and referenced everywhere.

Changes:
- Add Ignored condition type with WithIgnored/WithIgnoredCleared builder methods (put in place of the obsolete isExemptNamespace check) and a checkNamespaceOptIn reconciler method that uses a namespace lister
- Add namespace informer watch (namespace_handler.go) that re-enqueues ResourceOverrides when namespace labels change, enabling the condition to react to opt-in label adds/removes
- Add NamespaceOptInLabelKey constant to pkg/asset to use instead of copying the string to multiple locations
- Add unit tests for the namespace event handler and reconciler opt-in logic, and an e2e test covering the full Ignored condition lifecycle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Resource overrides now apply only to namespaces explicitly opted in with the designated label.
- Added an `Ignored` condition for namespaces that are not opted in.
- Namespace label changes automatically trigger reconciliation and update override status.
- Added a public constant for the namespace opt-in label key.
- The `Ignored` condition clears automatically when a namespace opts in.

## Updates

- Renamed the exemption reason to `NamespaceNotOptedIn`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->